### PR TITLE
FIX: Warn users that uploads are not encrypted.

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-uploads.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-uploads.js.es6
@@ -1,0 +1,23 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "hook-uploads",
+
+  initialize(container) {
+    const siteSettings = container.lookup("site-settings:main");
+    if (!siteSettings.encrypt_enabled) {
+      return;
+    }
+
+    withPluginApi("0.8.27", api => {
+      api.addComposerUploadHandler([".*"], () => {
+        const controller = container.lookup("controller:composer");
+        if (controller.get("model.isEncrypted")) {
+          bootbox.alert(I18n.t("encrypt.encrypted_uploads"));
+          return false;
+        }
+        return true;
+      });
+    });
+  }
+};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8,6 +8,8 @@ en:
       encrypted_topic_title: "A secret message"
       encrypted_icon_title: "This message is end-to-end encrypted."
 
+      encrypted_uploads: "Uploads cannot be encrypted at this time."
+
       checkbox:
         checked: "This message will be end-to-end encrypted."
         unchecked: "Click the lock symbol to encrypt this message."


### PR DESCRIPTION
To be merged after discourse/discourse#6969.