### PR TITLE
TEMP FIX: prevents actions on destroyed container if save happens late

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-draft.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-draft.js.es6
@@ -37,6 +37,10 @@ export default {
 
     Draft.reopenClass({
       save(draftKey, sequence, data) {
+        if (!container || container.isDestroyed || container.isDestroying) {
+          return this._super.call(this, ...arguments);
+        }
+
         // TODO: https://github.com/emberjs/ember.js/issues/15291
         let { _super } = this;
 


### PR DESCRIPTION
It was crashing with discourse-spoiler-alert plugin tests if tests were running after encrypt tests.