### PR TITLE
FIX: Replace isAnImage with isImage from core

### DIFF
--- a/assets/javascripts/lib/uploadHandler.js.es6
+++ b/assets/javascripts/lib/uploadHandler.js.es6
@@ -1,4 +1,5 @@
 import { isImage } from "discourse/lib/uploads";
+import { Promise } from "rsvp";
 
 export function fetchDataPromise(file, uploadsUrl) {
   if (!isImage(file.name)) {

--- a/assets/javascripts/lib/uploadHandler.js.es6
+++ b/assets/javascripts/lib/uploadHandler.js.es6
@@ -1,0 +1,48 @@
+import { isImage } from "discourse/lib/uploads";
+
+export function fetchDataPromise(file, uploadsUrl) {
+  if (!isImage(file.name)) {
+    return Promise.resolve({ original_filename: file.name });
+  }
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = err => reject(err);
+    img.src = window.URL.createObjectURL(file);
+    uploadsUrl[file.name] = img.src;
+  }).then(img => {
+    const ratio = Math.min(
+      Discourse.SiteSettings.max_image_width / img.width,
+      Discourse.SiteSettings.max_image_height / img.height
+    );
+
+    return {
+      original_filename: file.name,
+      width: img.width,
+      height: img.height,
+      thumbnail_width: Math.floor(img.width * ratio),
+      thumbnail_height: Math.floor(img.height * ratio)
+    };
+  });
+}
+
+export function fetchDecryptedPromise(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = err => reject(err);
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+export function fetchKeyPromise() {
+  return new Promise((resolve, reject) => {
+    window.crypto.subtle
+      .generateKey({ name: "AES-GCM", length: 256 }, true, [
+        "encrypt",
+        "decrypt"
+      ])
+      .then(resolve, reject);
+  });
+}

--- a/test/javascripts/lib/uploadHandler-test.js.es6
+++ b/test/javascripts/lib/uploadHandler-test.js.es6
@@ -13,7 +13,7 @@ test("fetchDataPromise - image file", async assert => {
   });
 
   // suppress the image onerror, it is not important
-  fetchDataPromise(file, uploadsUrl).catch(e => console.log(e));
+  fetchDataPromise(file, uploadsUrl).catch(() => null);
   assert.ok(
     uploadsUrl[file.name],
     "it loads the image and adds it to uploadsUrl"

--- a/test/javascripts/lib/uploadHandler-test.js.es6
+++ b/test/javascripts/lib/uploadHandler-test.js.es6
@@ -1,0 +1,30 @@
+import { fetchDataPromise } from "discourse/plugins/discourse-encrypt/lib/uploadHandler";
+
+QUnit.module("discourse-encrypt:lib:uploadHander");
+
+let testImageBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+test("fetchDataPromise - image file", async assert => {
+  let uploadsUrl = {};
+  let file = new File([window.atob(testImageBase64)], "test.png", {
+    type: "image/png",
+    encoding: "utf-8"
+  });
+
+  // suppress the image onerror, it is not important
+  fetchDataPromise(file, uploadsUrl).catch(e => console.log(e));
+  assert.ok(
+    uploadsUrl[file.name],
+    "it loads the image and adds it to uploadsUrl"
+  );
+});
+
+test("fetchDataPromise - other file", async assert => {
+  let uploadsUrl = {};
+  let file = new File(["test"], "test.txt", { type: "text/plain" });
+
+  fetchDataPromise(file, uploadsUrl).then(result => {
+    assert.equal(result.original_filename, "test.txt");
+  });
+});


### PR DESCRIPTION
Replace isAnImage with isImage from core to fix upload errors on encrypted messages.

* Also split functions from hook-encrypt-upload to new
  file for easier testing and to catch any future regressions
* Add qunit test