### PR TITLE
FIX: When encrypt is enabled, secure message by default

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-composer.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-composer.js.es6
@@ -28,12 +28,12 @@ export default {
 
     // Check recipients and show encryption status in composer.
     Composer.reopen({
-      updateEncryptProperties() {
+      updateEncryptProperties(newMessage) {
         const encryptedTopic = this.topic && this.topic.encrypted_title;
         const canEncryptTopic = this.topic && hasTopicKey(this.topic.id);
         this.setProperties({
           /** @var Whether the current message is going to be encrypted. */
-          isEncrypted: encryptedTopic && canEncryptTopic,
+          isEncrypted: (encryptedTopic && canEncryptTopic) || newMessage,
           /** @var Disable encrypt indicator to enforce encrypted message, if
                    message is encrypted, or enforce decrypted message if one
                    of the recipients does not have encryption enabled. */
@@ -47,17 +47,17 @@ export default {
 
       @on("init")
       initEncrypt() {
-        this.updateEncryptProperties();
+        this.updateEncryptProperties(true);
       },
 
       @observes("creatingPrivateMessage", "topic")
       updateComposerEncrypt() {
-        this.updateEncryptProperties();
+        this.updateEncryptProperties(false);
       },
 
-      @observes("targetUsernames")
+      @observes("targetRecipients")
       checkKeys() {
-        if (!this.targetUsernames) {
+        if (!this.targetRecipients) {
           this.setProperties({
             isEncrypted: true,
             disableEncryptIndicator: false,
@@ -66,7 +66,7 @@ export default {
           return;
         }
 
-        const usernames = this.targetUsernames.split(",");
+        const usernames = this.targetRecipients.split(",");
         usernames.push(this.user.username);
 
         const groupNames = new Set(this.site.groups.map(g => g.name));

--- a/assets/javascripts/discourse/initializers/hook-composer.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-composer.js.es6
@@ -28,7 +28,7 @@ export default {
 
     // Check recipients and show encryption status in composer.
     Composer.reopen({
-      updateEncryptProperties(newMessage) {
+      updateEncryptProperties({ newMessage }) {
         const encryptedTopic = this.topic && this.topic.encrypted_title;
         const canEncryptTopic = this.topic && hasTopicKey(this.topic.id);
         this.setProperties({
@@ -47,12 +47,12 @@ export default {
 
       @on("init")
       initEncrypt() {
-        this.updateEncryptProperties(true);
+        this.updateEncryptProperties({ newMessage: true });
       },
 
       @observes("creatingPrivateMessage", "topic")
       updateComposerEncrypt() {
-        this.updateEncryptProperties(false);
+        this.updateEncryptProperties({ newMessage: false });
       },
 
       @observes("targetRecipients")

--- a/test/javascripts/acceptance/encrypt-test.js.es6
+++ b/test/javascripts/acceptance/encrypt-test.js.es6
@@ -233,7 +233,6 @@ test("posting does not leak plaintext", async assert => {
   await click("#create-topic");
   await composerActions.expand();
   await composerActions.selectRowByValue("reply_as_private_message");
-  await click(".reply-details a");
   await fillIn("#private-message-users", "admin");
   await keyEvent("#private-message-users", "keydown", 8);
   await keyEvent("#private-message-users", "keydown", 13);


### PR DESCRIPTION
When public/private keys are generated, the private message should be secured by default.

Also, I found a bug. I needed to rename `targetUsername` to `targetRecipients` due to that commit https://github.com/discourse/discourse/commit/eef21625c6b9dd589573bc1771c7075a12e0abc9

Now, when a user without generated keys are added to PM, the secure message becomes unsecured

![iLg6YMXgEV mp4](https://user-images.githubusercontent.com/72780/74288159-cafd3a80-4d7f-11ea-988a-2ff0bf2a129a.gif)



