### PR TITLE
FIX: dont display double agent

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-decrypt-topic.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-decrypt-topic.js.es6
@@ -102,7 +102,7 @@ export default {
       ".title",
       { addIcon: true }
     );
-    decryptElements("a.topic-link[data-topic-id]", "span", { addIcon: true });
+    decryptElements("a.topic-link[data-topic-id]", "span");
     decryptElements("a.topic-link[data-topic-id]", { addIcon: true });
     decryptElements("a.raw-topic-link[data-topic-id]", { addIcon: true });
     decryptElements(".quick-access-panel span[data-topic-id]");


### PR DESCRIPTION
Joffrey refactored private message title and he introduced private message wrapper
https://github.com/discourse/discourse/commit/6abc2f5072fef6d8088698b60c7d65fba5e36857#diff-9d0c62b053b74993e2b60802a4bfc2e3R2

He also changed the plugin to use that wrapper when we replace the icon
https://github.com/discourse/discourse-encrypt/commit/03274fb54f6cf5cbc1d6be1a88f7582f09975e60

So currently, we are replacing original icon + adding new one which is creating double security
<img width="158" alt="msedge_8IhOkElF0B" src="https://user-images.githubusercontent.com/72780/74703496-7109e280-5261-11ea-8f73-99bd5ce2c35c.png">

After the fix, it looks like this
<img width="162" alt="msedge_wg5FMiL1pm" src="https://user-images.githubusercontent.com/72780/74703527-90087480-5261-11ea-9540-2547ff34ea35.png">

