### PR TITLE
FIX: default encryption could be overwritten

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-action-after/encrypt.js.es6
+++ b/assets/javascripts/discourse/connectors/composer-action-after/encrypt.js.es6
@@ -43,6 +43,7 @@ export default {
         this.set("model.showEncryptError", true);
         if (!this.get("model.disableEncryptIndicator")) {
           this.set("model.isEncrypted", !this.get("model.isEncrypted"));
+          this.set("model.overwriteDefault", true);
         }
       }
     });

--- a/assets/javascripts/discourse/initializers/hook-composer.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-composer.js.es6
@@ -31,11 +31,15 @@ export default {
       updateEncryptProperties() {
         const encryptedTopic = this.topic && this.topic.encrypted_title;
         const canEncryptTopic = this.topic && hasTopicKey(this.topic.id);
+        const newIsEncryped =
+          (encryptedTopic && canEncryptTopic) ||
+          (this.overwriteDefault
+            ? this.isEncrypted
+            : this.isNew && this.creatingPrivateMessage);
+
         this.setProperties({
           /** @var Whether the current message is going to be encrypted. */
-          isEncrypted:
-            (encryptedTopic && canEncryptTopic) ||
-            (this.isNew && this.creatingPrivateMessage),
+          isEncrypted: newIsEncryped,
           /** @var Disable encrypt indicator to enforce encrypted message, if
                    message is encrypted, or enforce decrypted message if one
                    of the recipients does not have encryption enabled. */
@@ -91,6 +95,7 @@ export default {
             if (!userKeys[username]) {
               this.setProperties({
                 isEncrypted: false,
+                overwriteDefault: true,
                 disableEncryptIndicator: true,
                 encryptError: I18n.t("encrypt.composer.user_has_no_key", {
                   username


### PR DESCRIPTION
The bug was introduced in that commit (message encrypted by default)- https://github.com/discourse/discourse-encrypt/commit/029ef4a63ff1a2b937671b89e0f7b80b00e145f9

Problem was that the user could not overwrite default encryption. So the message was always encrypted when encryption was enabled. We need to allow the user to overwrite that behaviour.