### PR TITLE
FIX: display decrypting message during decrypt process

### DIFF
--- a/assets/javascripts/discourse/controllers/activate-encrypt.js.es6
+++ b/assets/javascripts/discourse/controllers/activate-encrypt.js.es6
@@ -35,7 +35,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
         .then(() => {
           this.appEvents.trigger("encrypt:status-changed");
           this.models.forEach(model => {
-            model.state.decrypting = false;
+            model.state.decrypting = true;
             model.state.decrypted = false;
             model.scheduleRerender();
           });


### PR DESCRIPTION
A little bit more smooth experience when decrypting

before:
![before mp4](https://user-images.githubusercontent.com/72780/79187921-017b3280-7e61-11ea-840e-043beed8d45e.gif)

after:
![after mp4](https://user-images.githubusercontent.com/72780/79187937-063fe680-7e61-11ea-91d8-6d21419517b5.gif)
