### PR TITLE
FIX: do not add encrypted attachments to emails

### DIFF
--- a/lib/email_sender_extensions.rb
+++ b/lib/email_sender_extensions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module EmailSenderExtensions
+  def add_attachments(post)
+    return if post.is_encrypted?
+    super
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,6 +29,7 @@ after_initialize do
   load File.expand_path('../lib/topic_extensions.rb', __FILE__)
   load File.expand_path('../lib/topics_controller_extensions.rb', __FILE__)
   load File.expand_path('../lib/user_extensions.rb', __FILE__)
+  load File.expand_path('../lib/email_sender_extensions.rb', __FILE__)
 
   class DiscourseEncrypt::Engine < Rails::Engine
     engine_name DiscourseEncrypt::PLUGIN_NAME
@@ -52,6 +53,7 @@ after_initialize do
     Topic.class_eval            { prepend TopicExtensions }
     TopicsController.class_eval { prepend TopicsControllerExtensions }
     User.class_eval             { prepend UserExtensions }
+    Email::Sender.class_eval    { prepend EmailSenderExtensions }
   end
 
   # Send plugin-specific topic data to client via serializers.

--- a/spec/lib/email_sender_spec.rb
+++ b/spec/lib/email_sender_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Email::Sender do
+  fab!(:small_pdf) do
+    SiteSetting.authorized_extensions = 'pdf'
+    UploadCreator.new(file_from_fixtures("small.pdf", "pdf"), "small.pdf")
+      .create_for(Discourse.system_user.id)
+  end
+
+  context "encrypted" do
+    fab!(:encrypted_topic) { Fabricate(:encrypt_topic) }
+    fab!(:encrypted_post) { Fabricate(:encrypt_post, topic: encrypted_topic) }
+    fab!(:encrypted_reply) do
+      raw = <<~RAW
+      0$ciphertextbase64encoded==
+      Hello world!
+      #{UploadMarkdown.new(small_pdf).attachment_markdown}
+      RAW
+      reply = Fabricate(:encrypt_post, raw: raw, topic: encrypted_post.topic, user: Fabricate(:user))
+      reply.link_post_uploads
+      reply
+    end
+    fab!(:notification) { Fabricate(:posted_notification, user: encrypted_post.user, post: encrypted_reply) }
+    let(:message) do
+      UserNotifications.user_posted(
+        encrypted_post.user,
+        post: encrypted_reply,
+        notification_type: notification.notification_type,
+        notification_data_hash: notification.data_hash
+      )
+    end
+
+    it "removes attachments from the email" do
+      SiteSetting.email_total_attachment_size_limit_kb = 10_000
+      Email::Sender.new(message, :valid_type).send
+
+      expect(message.attachments.length).to eq(0)
+    end
+  end
+
+  context "plain post" do
+    fab!(:post) { Fabricate(:post) }
+    fab!(:reply) do
+      raw = <<~RAW
+      Hello world!
+      #{UploadMarkdown.new(small_pdf).attachment_markdown}
+      RAW
+      reply = Fabricate(:post, raw: raw, topic: post.topic, user: Fabricate(:user))
+      reply.link_post_uploads
+      reply
+    end
+    fab!(:notification) { Fabricate(:posted_notification, user: post.user, post: reply) }
+    let(:message) do
+      UserNotifications.user_posted(
+        post.user,
+        post: reply,
+        notification_type: notification.notification_type,
+        notification_data_hash: notification.data_hash
+      )
+    end
+
+    it "adds non-image uploads as attachments to the email" do
+      SiteSetting.email_total_attachment_size_limit_kb = 10_000
+      Email::Sender.new(message, :valid_type).send
+
+      expect(message.attachments.length).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
We should skip sending encrypted attachments as they are pointless and
cannot be decrypted anyway. If a user wants to see them, they need to
decrypt them in Discourse itself.