### PR TITLE
FIX: decrypt encrypted title in the search

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-decrypt-topic.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-decrypt-topic.js.es6
@@ -56,6 +56,12 @@ function decryptElements(containerSelector, elementSelector, opts) {
     $(this)
       .find(".edit-topic")
       .hide();
+
+    // Hide excerpt in search
+    $(this)
+      .parents(".search-link")
+      .find(".blurb")
+      .hide();
   });
 }
 
@@ -83,10 +89,13 @@ export default {
       }
     });
 
-    // Decrypt notifications when opening the user menu.
+    // Decrypt notifications when opening the user menu or searching.
     withPluginApi("0.8.31", api => {
       api.decorateWidget("header:after", helper => {
-        if (helper.widget.state.userVisible) {
+        if (
+          helper.widget.state.userVisible ||
+          helper.widget.state.searchVisible
+        ) {
           debounce(self, self.decryptTitles, 500);
         }
       });
@@ -105,6 +114,7 @@ export default {
     decryptElements("a.topic-link[data-topic-id]", { addIcon: true });
     decryptElements("a.raw-topic-link[data-topic-id]", { addIcon: true });
     decryptElements(".quick-access-panel span[data-topic-id]");
+    decryptElements(".search-result-topic span[data-topic-id]");
   },
 
   decryptDocTitle(data) {


### PR DESCRIPTION
When a user is searching for personal messages, if they are encrypted, topic should be decrypted to show something useful.

Also, this is a little bit of an edge case, so to simplify, the excerpt below the title is hidden

Related discourse PR (include data-topic-id in search) - https://github.com/discourse/discourse/pull/9435

![decrypt-search-title mp4](https://user-images.githubusercontent.com/72780/79403038-0959e480-7fd1-11ea-9695-9d8555a3427b.gif)
