### PR TITLE
FIX: information about reply via email is removed

### DIFF
--- a/app/mailers/user_notifications_extensions.rb
+++ b/app/mailers/user_notifications_extensions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module UserNotificationsExtensions
+  def notification_email(user, opts)
+    opts[:allow_reply_by_email] = false if opts[:post] && opts[:post].is_encrypted?
+    super
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -30,6 +30,7 @@ after_initialize do
   load File.expand_path('../lib/topics_controller_extensions.rb', __FILE__)
   load File.expand_path('../lib/user_extensions.rb', __FILE__)
   load File.expand_path('../lib/email_sender_extensions.rb', __FILE__)
+  load File.expand_path('../app/mailers/user_notifications_extensions.rb', __FILE__)
 
   class DiscourseEncrypt::Engine < Rails::Engine
     engine_name DiscourseEncrypt::PLUGIN_NAME
@@ -49,11 +50,12 @@ after_initialize do
   end
 
   reloadable_patch do |plugin|
-    Post.class_eval             { prepend PostExtensions }
-    Topic.class_eval            { prepend TopicExtensions }
-    TopicsController.class_eval { prepend TopicsControllerExtensions }
-    User.class_eval             { prepend UserExtensions }
-    Email::Sender.class_eval    { prepend EmailSenderExtensions }
+    Post.class_eval              { prepend PostExtensions }
+    Topic.class_eval             { prepend TopicExtensions }
+    TopicsController.class_eval  { prepend TopicsControllerExtensions }
+    User.class_eval              { prepend UserExtensions }
+    Email::Sender.class_eval     { prepend EmailSenderExtensions }
+    UserNotifications.class_eval { prepend UserNotificationsExtensions }
   end
 
   # Send plugin-specific topic data to client via serializers.


### PR DESCRIPTION
When we send email notifications about the encrypted private message - instruction that user can respond via email should be removed.

In addition, the message should be sent from no-reply email address.