### PR TITLE
FIX: decorate decrypted images with lightbox

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-decrypt-post.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-decrypt-post.js.es6
@@ -11,6 +11,8 @@ import showModal from "discourse/lib/show-modal";
 import { cookAsync } from "discourse/lib/text";
 import { markdownNameFromFileName } from "discourse/lib/uploads";
 import { base64ToBuffer } from "discourse/plugins/discourse-encrypt/lib/base64";
+import lightbox from "discourse/lib/lightbox";
+
 import {
   ENCRYPT_DISABLED,
   getDebouncedUserIdentities,
@@ -225,6 +227,18 @@ function postProcessPost(siteSettings, topicId, $post) {
       linkSeenMentions($post, siteSettings)
     );
   }
+
+  $post
+    .find(".cooked img")
+    .not($(".d-lazyload-hidden"))
+    .each(function() {
+      $(this).wrap(
+        '<div class="lightbox-wrapper"><a class="lightbox" href="' +
+          $(this).attr("src") +
+          '"</a></div>'
+      );
+    });
+  lightbox($post[0], siteSettings);
 
   try {
     const { linkSeenHashtags, fetchUnseenHashtags } = require.call(


### PR DESCRIPTION
For classic posts, when we generate cooked version we wrap images with lightbox classes

https://github.com/discourse/discourse/blob/master/lib/cooked_post_processor.rb#L416

However, for encrypted message we don't have cooked version so we need to wrap images after successful decryption.

![29nqk8oEYi](https://user-images.githubusercontent.com/72780/91143137-625f2500-e6f5-11ea-9af6-c1b4c595d197.gif)
