### PR TITLE
FIX: encrypt works for a user who cannot edit posts

### DIFF
--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -136,7 +136,7 @@ class DiscourseEncrypt::EncryptController < ApplicationController
 
     post = Post.find_by(id: post_id)
 
-    raise Discourse::InvalidAccess if post.user != current_user
+    guardian.ensure_can_encrypt_post!(post)
 
     if post.updated_at < 5.seconds.ago
       return render_json_error(I18n.t('too_late_to_edit'), status: 409)

--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -135,7 +135,8 @@ class DiscourseEncrypt::EncryptController < ApplicationController
     encrypted_raw = params.require(:encrypted_raw)
 
     post = Post.find_by(id: post_id)
-    guardian.ensure_can_edit!(post)
+
+    raise Discourse::InvalidAccess if post.user != current_user
 
     if post.updated_at < 5.seconds.ago
       return render_json_error(I18n.t('too_late_to_edit'), status: 409)

--- a/plugin.rb
+++ b/plugin.rb
@@ -172,6 +172,10 @@ after_initialize do
     end
   end
 
+  add_to_class(:guardian, :can_encrypt_post?) do |post|
+    SiteSetting.encrypt_enabled? && post.topic.is_encrypted? && post.user == @user
+  end
+
   #
   # Hide cooked content.
   #

--- a/spec/requests/encrypt_controller_spec.rb
+++ b/spec/requests/encrypt_controller_spec.rb
@@ -109,4 +109,24 @@ describe DiscourseEncrypt::EncryptController do
       expect(response.status).to eq(200)
     end
   end
+
+  context '#update_post' do
+    let!(:post) { Fabricate(:encrypt_post) }
+
+    before do
+      SiteSetting.min_trust_to_edit_post = 2
+    end
+
+    it 'is not raising error when user cannot edit because min trust level' do
+      sign_in(post.user)
+      put '/encrypt/post', params: { post_id: post.id, encrypted_raw: 'some encrypted raw' }
+      expect(response.status).to eq(200)
+    end
+
+    it 'does not work if user is not author of post' do
+      sign_in(user)
+      put '/encrypt/post', params: { post_id: post.id, encrypted_raw: 'some encrypted raw' }
+      expect(response.status).to eq(403)
+    end
+  end
 end


### PR DESCRIPTION
The bug mentioned here: https://meta.discourse.org/t/min-trust-to-edit-post-setting-interfering-with-discourse-encrypt/163245

Using the guardian was the best and safest approach. 
However, there is a situation when the user cannot edit posts. For example when `min_trust_to_edit_post` is set higher than the user trust level. 
Therefore we can simply check if the user is author of the post.