### PR TITLE
FIX: Automatically add .encrypted to authorized extensions

### DIFF
--- a/lib/site_setting_extensions.rb
+++ b/lib/site_setting_extensions.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module SiteSettingExtensions
+  def authorized_extensions
+    original_extensions = super
+
+    if extensions = original_extensions.split("|")
+      if !extensions.include?("*")
+        extensions.reject! { |ext| ext.ends_with?(".encrypted") }
+        extensions += extensions.map { |ext| "#{ext}.encrypted" }
+
+        return extensions.uniq.join("|")
+      end
+    end
+
+    original_extensions
+  end
+
+  def authorized_extensions=(extensions)
+    extensions = extensions
+      .split("|")
+      .reject { |ext| ext.ends_with?(".encrypted") }
+      .join("|")
+
+    super(extensions)
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,6 +33,7 @@ after_initialize do
   load File.expand_path('../lib/user_extensions.rb', __FILE__)
   load File.expand_path('../lib/email_sender_extensions.rb', __FILE__)
   load File.expand_path('../app/mailers/user_notifications_extensions.rb', __FILE__)
+  load File.expand_path('../lib/site_setting_extensions.rb', __FILE__)
 
   class DiscourseEncrypt::Engine < Rails::Engine
     engine_name DiscourseEncrypt::PLUGIN_NAME
@@ -52,13 +53,15 @@ after_initialize do
   end
 
   reloadable_patch do |plugin|
+    Email::Sender.class_eval         { prepend EmailSenderExtensions }
     Post.class_eval                  { prepend PostExtensions }
+    PostActionsController.class_eval { prepend PostActionsControllerExtensions }
     Topic.class_eval                 { prepend TopicExtensions }
     TopicsController.class_eval      { prepend TopicsControllerExtensions }
-    PostActionsController.class_eval { prepend PostActionsControllerExtensions }
     User.class_eval                  { prepend UserExtensions }
-    Email::Sender.class_eval         { prepend EmailSenderExtensions }
     UserNotifications.class_eval     { prepend UserNotificationsExtensions }
+
+    SiteSetting.singleton_class.prepend SiteSettingExtensions
   end
 
   # Send plugin-specific topic data to client via serializers.

--- a/spec/lib/site_setting_spec.rb
+++ b/spec/lib/site_setting_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SiteSettingExtensions do
+  let(:default_extensions) { ["jpg", "jpeg", "png", "gif", "heic", "heif"] }
+  let(:encrypted_extensions) { default_extensions.map { |e| e + ".encrypted" } }
+  let(:all_extensions) { default_extensions + encrypted_extensions }
+
+  it "adds .encrypted file extensions to default authorized_extensions (getter)" do
+    expect(SiteSetting.authorized_extensions.split("|")).to match_array(all_extensions)
+  end
+
+  it "provider does not save .encrypted file extensions" do
+    SiteSetting.authorized_extensions += "|txt"
+    expect(SiteSetting.authorized_extensions.split("|")).to match_array(all_extensions + ["txt", "txt.encrypted"])
+    expect(SiteSetting.provider.find(:authorized_extensions)&.value.split("|")).to match_array(default_extensions + ["txt"])
+  end
+end


### PR DESCRIPTION
For each authorized extension, it adds another one that ends in
.encrypted.

This pull request cannot be merged until the code in core is amended
to allow for double extensions (for example .gif.encrypted).