### PR TITLE
FIX: Check if arguments are valid

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-gather-keys.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-gather-keys.js.es6
@@ -56,7 +56,7 @@ export default {
     // Hook `Topic` model to gather encrypted topic keys.
     Topic.reopenClass({
       create(args) {
-        if (args.topic_key) {
+        if (args && args.topic_key) {
           putTopicKey(args.id, args.topic_key);
           putTopicTitle(args.id, args.encrypted_title);
         }


### PR DESCRIPTION
Topic.create() used to throw a TypeError because it expected
arguments[0] to exist and be an Object.