### PR TITLE
FIX: email about encrypted message contains the topic id

### DIFF
--- a/app/mailers/user_notifications_extensions.rb
+++ b/app/mailers/user_notifications_extensions.rb
@@ -2,7 +2,10 @@
 
 module UserNotificationsExtensions
   def notification_email(user, opts)
-    opts[:allow_reply_by_email] = false if opts[:post] && opts[:post].is_encrypted?
+    if opts[:post] && opts[:post].is_encrypted?
+      opts[:allow_reply_by_email] = false
+      opts[:notification_data_hash][:topic_title] = "#{opts[:post].topic.title} ##{opts[:post].topic.id}"
+    end
     super
   end
 end

--- a/spec/lib/email_sender_spec.rb
+++ b/spec/lib/email_sender_spec.rb
@@ -42,13 +42,14 @@ describe Email::Sender do
       )
     end
 
-    it "removes attachments from the email and does not allow to respond via email" do
+    it "removes attachments from the email, does not allow to respond via email and adds topic id to subject" do
       SiteSetting.email_total_attachment_size_limit_kb = 10_000
       Email::Sender.new(message, :valid_type).send
 
       expect(message.attachments.length).to eq(0)
       expect(message.reply_to).to eq(["noreply@test.localhost"])
       expect(message.body.raw_source).not_to match("or reply to this email to respond")
+      expect(message.subject).to match("[Discourse] [PM] A secret message ##{encrypted_topic.id}")
     end
   end
 
@@ -80,6 +81,7 @@ describe Email::Sender do
       expect(message.attachments.length).to eq(1)
       expect(message.reply_to).to eq(["test+%{reply_key}@example.com"])
       expect(message.body.raw_source).to match("or reply to this email to respond")
+      expect(message.subject).to match("[Discourse] #{post.topic.title}")
     end
   end
 end


### PR DESCRIPTION
Topic ID will make the subject of email encrypted message unique (for example `[Discourse] [PM] A secret message #24222`).

This is necessary to prevent incorrect grouping of those emails by some email providers.