### PR TITLE
FIX: do not error timer when post is already deleted

### DIFF
--- a/app/jobs/scheduled/encrypted_post_timer_evaluator.rb
+++ b/app/jobs/scheduled/encrypted_post_timer_evaluator.rb
@@ -8,9 +8,9 @@ module Jobs
       EncryptedPostTimer.pending.order(delete_at: :asc).find_each do |encrypted_post_timer|
         ActiveRecord::Base.transaction do
           encrypted_post_timer.touch(:destroyed_at)
-          next if !encrypted_post_timer.post.persisted?
+          next if !encrypted_post_timer.post&.persisted?
           posts_to_delete(encrypted_post_timer).each do |post|
-            next if !post.persisted?
+            next if !post&.persisted?
             PostDestroyer.new(post.user, post, permanent: true).destroy
           end
         end

--- a/spec/jobs/encrypted_post_timer_evaluator_spec.rb
+++ b/spec/jobs/encrypted_post_timer_evaluator_spec.rb
@@ -45,5 +45,12 @@ describe Jobs::EncryptedPostTimerEvaluator do
       expect(topic.reload.persisted?).to be true
       expect(encrypted_post_timer.reload.destroyed_at).not_to be nil
     end
+
+    it 'does not error when post is already deleted' do
+      encrypted_post_timer = EncryptedPostTimer.create!(post_id: -5, delete_at: 1.hour.from_now)
+      freeze_time 61.minutes.from_now
+      described_class.execute({})
+      expect(encrypted_post_timer.reload.destroyed_at).not_to be nil
+    end
   end
 end


### PR DESCRIPTION
Fix for error  - NoMethodError (undefined method `persisted?' for nil:NilClass)