### PR TITLE
FIX: timer look when long user title

### DIFF
--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -119,6 +119,7 @@ pre.exported-key-pair {
 .encrypted-post-timer-counter {
   margin-left: 0.5em;
   color: var(--danger, $danger);
+  flex: 0 0 auto;
 
   svg {
     margin-left: 0.5em;


### PR DESCRIPTION
Expand timer div on mobile when the title is too long

Before:
![image](https://user-images.githubusercontent.com/72780/99601145-f3267200-2a52-11eb-9e5b-4a12d3b6992d.png)


After:
![image](https://user-images.githubusercontent.com/72780/99601110-e144cf00-2a52-11eb-8de1-bd04f0693c3c.png)
