### PR TITLE
FIX: Make sure all user identity promises are eventually resolved

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-decrypt-post.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-decrypt-post.js.es6
@@ -16,7 +16,7 @@ import lightbox from "discourse/lib/lightbox";
 
 import {
   ENCRYPT_DISABLED,
-  getDebouncedUserIdentities,
+  getDebouncedUserIdentity,
   getEncryptionStatus,
   getIdentity,
   getTopicKey,
@@ -400,10 +400,10 @@ export default {
                   .then((key) => decrypt(key, ciphertext))
                   .then((plaintext) => {
                     if (plaintext.signature) {
-                      getDebouncedUserIdentities([plaintext.signed_by_name])
-                        .then((identities) => {
+                      getDebouncedUserIdentity(plaintext.signed_by_name)
+                        .then((userIdentity) => {
                           return verify(
-                            identities[plaintext.signed_by_name].signPublic,
+                            userIdentity.signPublic,
                             plaintext,
                             ciphertext
                           );


### PR DESCRIPTION
getDebouncedUserIdentities used to resolve only the first returned
promise. It has been renamed to getDebouncedUserIdentity to simplify
the API and the logic behind it.

The green signature checkmark displayed in the UI is displayed only
after the verification process finishes. This did not happen because
the whole process was stuck waiting for the the promise returned by
getDebouncedUserIdentities to be resolved.