### PR TITLE
FIX: email annotation that message will be deleted

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -15,6 +15,7 @@ en:
       encrypted_topic_title: "A secret message"
       encrypted_post: "This is a secret message with end to end encryption. To view it, you must be invited to this topic."
       encrypted_post_email: "This is a secret message with end to end encryption. You must visit the topic to view it."
+      encrypted_post_email_timer_annotation: "This message will be permanently deleted at %{delete_at}"
       encrypted_icon_title: "This message is end-to-end encrypted."
 
       encrypted_uploads: "Uploads cannot be encrypted at this time."

--- a/plugin.rb
+++ b/plugin.rb
@@ -225,6 +225,10 @@ after_initialize do
   on(:reduce_cooked) do |fragment, post|
     if post&.is_encrypted?
       fragment.inner_html = "<p>#{I18n.t('js.encrypt.encrypted_post_email')}</p>"
+      if timer = (post.encrypted_post_timer || post.topic.posts.first.encrypted_post_timer)
+        fragment.inner_html += "<p>#{I18n.t('js.encrypt.encrypted_post_email_timer_annotation', delete_at: I18n.l(timer.delete_at, format: :long))}</p>"
+      end
+      fragment
     end
   end
 


### PR DESCRIPTION
Annotation that encrypted message will be permanently destroyed was added to e-mail. It is important for the user to know that they have limited time to read the message.

It was mentioned here: https://meta.discourse.org/t/discourse-encrypt-for-private-messages/107918/127