### PR TITLE
DEV: Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-decrypt-post.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-decrypt-post.js.es6
@@ -1,5 +1,5 @@
 import I18n from "I18n";
-import { debounce } from "@ember/runloop";
+import debounce from "discourse/plugins/discourse-encrypt/lib/debounce";
 import { iconHTML, iconNode } from "discourse-common/lib/icon-library";
 import { renderSpinner } from "discourse/helpers/loading-spinner";
 import { ajax } from "discourse/lib/ajax";

--- a/assets/javascripts/discourse/initializers/hook-decrypt-topic.js.es6
+++ b/assets/javascripts/discourse/initializers/hook-decrypt-topic.js.es6
@@ -1,5 +1,6 @@
 import I18n from "I18n";
-import { debounce, scheduleOnce } from "@ember/runloop";
+import { scheduleOnce } from "@ember/runloop";
+import debounce from "discourse/plugins/discourse-encrypt/lib/debounce";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { emojiUnescape } from "discourse/lib/text";

--- a/assets/javascripts/lib/debounce.js.es6
+++ b/assets/javascripts/lib/debounce.js.es6
@@ -1,0 +1,6 @@
+import discourseDebounce from "discourse-common/lib/debounce";
+import { debounce } from "@ember/runloop";
+
+// TODO: Remove this file and use discouseDebounce after the 2.7 release.
+const debounceFunction = discourseDebounce || debounce;
+export default debounceFunction;

--- a/assets/javascripts/lib/discourse.js.es6
+++ b/assets/javascripts/lib/discourse.js.es6
@@ -1,4 +1,4 @@
-import { debounce } from "@ember/runloop";
+import debounce from "discourse/plugins/discourse-encrypt/lib/debounce";
 import { ajax } from "discourse/lib/ajax";
 import {
   DB_NAME,
@@ -149,6 +149,7 @@ export function getDebouncedUserIdentity(username) {
       queuedUsernames[username] = [];
     }
     queuedUsernames[username].push({ resolve, reject });
+
     debounce(queuedUsernames, _getDebouncedUserIdentity, 500);
   });
 }


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.