### PR TITLE
DEV: Fix JS acceptance test

### DIFF
--- a/test/javascripts/acceptance/encrypt-test.js.es6
+++ b/test/javascripts/acceptance/encrypt-test.js.es6
@@ -249,9 +249,9 @@ acceptance("Encrypt", function (needs) {
       throw new Error("Another test is leaking composer state");
     }
 
-    await fillIn("#private-message-users", "admin");
-    await keyEvent("#private-message-users", "keydown", 8);
-    await keyEvent("#private-message-users", "keydown", 13);
+    // simulate selecting from autocomplete suggestions
+    await fillIn("#private-message-users .filter-input", "evilt");
+    await keyEvent("#private-message-users .filter-input", "keydown", 13);
 
     requests = [];
     await wait(


### PR DESCRIPTION
PR https://github.com/discourse/discourse/pull/11726 changes the composer's recipients selector from {{user-selector}} to the new {{email-group-user-chooser}}, and that change breaks the acceptance tests of this plugin since they expect {{user-selector}}. This PR fixes the tests.

Don't merge this until the core PR mentioned above is merged.