### PR TITLE
FIX: Improve warning for group PMs

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -35,7 +35,7 @@ en:
 
       composer:
         encrypt: "Encrypt message?"
-        group_not_allowed: "You are not allowed to send messages to groups."
+        group_not_allowed: "You are not allowed to send encrypted messages to groups."
         user_has_no_key: "Unfortunately %{username} did not enable encrypted messages."
 
       preferences:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -35,7 +35,7 @@ en:
 
       composer:
         encrypt: "Encrypt message?"
-        group_not_allowed: "You are not allowed to send encrypted messages to groups."
+        group_not_allowed: "Encryption disabled - unsupported for group messages."
         user_has_no_key: "Unfortunately %{username} did not enable encrypted messages."
 
       preferences:


### PR DESCRIPTION
Group PMs cannot be encrypted. The warning displayed in the composer has caused some confusion with users thinking they can't send group PMs at all. Add "encrypted" to the text to make it clear only encrypted messages can't be sent.

See https://meta.discourse.org/t/discourse-encrypt-for-private-messages/107918/136