### PR TITLE
FIX: Correctly check extension of encrypted images

### DIFF
--- a/lib/upload_validator_extensions.rb
+++ b/lib/upload_validator_extensions.rb
@@ -5,11 +5,11 @@ module UploadValidatorExtensions
     extension = File.extname(upload.original_filename)[1..-1] || ""
 
     if extension == "encrypted"
-      original_filename = upload.original_filename.gsub(/\.encrypted$/, "")
-      extension = File.extname(original_filename)[1..-1] || ""
+      filename = upload.original_filename.gsub(/\.encrypted$/, "")
+      extension = File.extname(filename)[1..-1] || ""
 
       if is_authorized?(upload, extension)
-        if FileHelper.is_supported_image?(upload.original_filename)
+        if FileHelper.is_supported_image?(filename)
           authorized_image_extension(upload, extension)
           maximum_image_file_size(upload)
         else

--- a/spec/lib/upload_validator_spec.rb
+++ b/spec/lib/upload_validator_spec.rb
@@ -16,4 +16,9 @@ describe UploadValidatorExtensions do
     expect { Fabricate(:upload, original_filename: "test.bar") }.not_to raise_exception
     expect { Fabricate(:upload, original_filename: "test.bar.encrypted") }.not_to raise_exception
   end
+
+  it "removes '.encrypted' extension and validates the real image extension" do
+    expect { Fabricate(:upload, original_filename: "test.jpg") }.not_to raise_exception
+    expect { Fabricate(:upload, original_filename: "test.jpg.encrypted") }.not_to raise_exception
+  end
 end


### PR DESCRIPTION
There are two sets of allowed extensions (one for images and one for
all the other files) and images were always checked against the wrong
set, which excludes all image extensions. For this reason, the check
for encrypted images always failed.

Co-authored-by: jbrw <jamie@goatforce5.org>