### PR TITLE
FIX: Allow quick access panels to load even if topic key is invalid

### DIFF
--- a/assets/javascripts/lib/discourse.js.es6
+++ b/assets/javascripts/lib/discourse.js.es6
@@ -269,7 +269,7 @@ export function waitForPendingTitles() {
   return Promise.all(
     Object.values(topicTitles)
       .filter((t) => !t.result)
-      .map((t) => t.promise)
+      .map((t) => t.promise.catch(() => null))
   );
 }
 


### PR DESCRIPTION
The waitForPendingTitles promise is intended to resolve once async
decryption work is done. We still want it to resolve successfully
even if the decryption failed, so that the UI continues to display.