### PR TITLE
FIX: private message email without in reply to section

### DIFF
--- a/app/mailers/user_notifications_extensions.rb
+++ b/app/mailers/user_notifications_extensions.rb
@@ -8,4 +8,15 @@ module UserNotificationsExtensions
     end
     super
   end
+
+  module ClassMethods
+    def get_context_posts(post, topic_user, user)
+      return [] if post.is_encrypted?
+      super
+    end
+  end
+
+  def self.prepended(mod)
+    mod.singleton_class.prepend(ClassMethods)
+  end
 end

--- a/lib/user_notification_renderer_extensions.rb
+++ b/lib/user_notification_renderer_extensions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module UserNotificationRendererExtensions
+  def render(*args)
+    post = args[0]&.dig(:locals, :post)
+    args[0][:locals][:in_reply_to_post] = nil if post&.is_encrypted?
+    super(*args)
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -40,6 +40,7 @@ after_initialize do
   load File.expand_path('../lib/topics_controller_extensions.rb', __FILE__)
   load File.expand_path('../lib/upload_validator_extensions.rb', __FILE__)
   load File.expand_path('../lib/user_extensions.rb', __FILE__)
+  load File.expand_path('../lib/user_notification_renderer_extensions.rb', __FILE__)
 
   class DiscourseEncrypt::Engine < Rails::Engine
     engine_name DiscourseEncrypt::PLUGIN_NAME
@@ -76,6 +77,7 @@ after_initialize do
     UserNotifications.class_eval     { prepend UserNotificationsExtensions }
 
     SiteSetting.singleton_class.prepend SiteSettingExtensions
+    UserNotificationRenderer.singleton_class.prepend UserNotificationRendererExtensions
   end
 
   # Send plugin-specific topic data to client via serializers.


### PR DESCRIPTION
Both "In replay to" and "Previous replies" sections should be removed from email as they don't contain any useful information in encrypted messages.

<img width="465" alt="Screen Shot 2021-03-31 at 2 26 34 pm" src="https://user-images.githubusercontent.com/72780/113086540-89eb1280-922d-11eb-928c-600a5aad1986.png">
