### PR TITLE
FIX: Populate all fields used for serialization

### DIFF
--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -137,6 +137,10 @@ class DiscourseEncrypt::EncryptController < ApplicationController
       .order(created_at: :desc)
       .limit(1000)
 
+    if SiteSetting.use_pg_headlines_for_excerpt
+      posts = posts.select("'' AS topic_title_headline", posts.arel.projections)
+    end
+
     topics = posts.map(&:topic)
 
     render json: success_json.merge(

--- a/assets/javascripts/discourse/initializers/add-search-results.js
+++ b/assets/javascripts/discourse/initializers/add-search-results.js
@@ -53,6 +53,7 @@ function getOrFetchCache(session) {
               topic.title = topic.fancy_title = decrypted.raw;
               addCacheItem(session, "topics", topic);
             })
+            .catch(() => {})
         );
       });
 

--- a/spec/requests/encrypt_controller_spec.rb
+++ b/spec/requests/encrypt_controller_spec.rb
@@ -110,6 +110,35 @@ describe DiscourseEncrypt::EncryptController do
     end
   end
 
+  context '#posts' do
+    let!(:topic) { Fabricate(:encrypt_topic, topic_allowed_users: [ Fabricate.build(:topic_allowed_user, user: user) ]) }
+    let!(:post) { Fabricate(:post, topic: topic) }
+
+    it 'does not work when not logged in' do
+      get '/encrypt/posts'
+      expect(response.status).to eq(404)
+    end
+
+    it 'fetches posts' do
+      sign_in(user)
+
+      get '/encrypt/posts'
+      expect(response.status).to eq(200)
+      expect(response.parsed_body['topics'].size).to eq(1)
+      expect(response.parsed_body['posts'].size).to eq(1)
+    end
+
+    it 'fetches posts when use_pg_headlines_for_excerpt is enabled' do
+      SiteSetting.use_pg_headlines_for_excerpt = true
+      sign_in(user)
+
+      get '/encrypt/posts'
+      expect(response.status).to eq(200)
+      expect(response.parsed_body['topics'].size).to eq(1)
+      expect(response.parsed_body['posts'].size).to eq(1)
+    end
+  end
+
   context '#update_post' do
     let!(:post) { Fabricate(:encrypt_post) }
 


### PR DESCRIPTION
Endpoint /encrypt/posts did not work when use_pg_headlines_for_excerpt
was enabled because not all fields used by SearchPostSerializer were
present.