### PR TITLE
PERF: Fetch only first posts for search cache

### DIFF
--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -133,6 +133,7 @@ class DiscourseEncrypt::EncryptController < ApplicationController
   def posts
     posts = Post
       .joins(:topic, topic: :encrypted_topics_users)
+      .where(post_number: 1)
       .where(encrypted_topics_users: { user_id: current_user.id })
       .order(created_at: :desc)
       .limit(1000)

--- a/assets/javascripts/discourse/initializers/add-search-results.js
+++ b/assets/javascripts/discourse/initializers/add-search-results.js
@@ -112,7 +112,7 @@ export default {
 
           if (cache.posts) {
             cache.posts.forEach((post) => {
-              if (!topics[post.topic_id]) {
+              if (post.post_number !== 1 || !topics[post.topic_id]) {
                 return;
               }
 

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -559,6 +559,16 @@ acceptance("Encrypt", function (needs) {
               post_number: 1,
               topic_id: 42,
             },
+            {
+              id: 43,
+              username: "foo",
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/f/eada6e/{size}.png",
+              created_at: "2021-01-01T12:00:00.000Z",
+              like_count: 0,
+              post_number: 2,
+              topic_id: 42,
+            },
           ],
         },
       ];
@@ -648,7 +658,7 @@ acceptance("Encrypt", function (needs) {
       ];
     });
 
-    await visit("/search?q=secret+in:personal");
+    await visit("/search?q=secret++in:personal");
     assert.equal(count(".fps-result"), 1);
     assert.equal(
       queryAll(".fps-result .topic-title").text().trim(),


### PR DESCRIPTION
At this moment, the search uses only the topic title. In this case, it
does not make sense to fetch all posts in a topic, but just the first
one.