### PR TITLE
FIX: Fallback to file size to lookup file info

### DIFF
--- a/assets/javascripts/lib/uploads.js
+++ b/assets/javascripts/lib/uploads.js
@@ -1,7 +1,7 @@
 import { isImage } from "discourse/lib/uploads";
 import { Promise } from "rsvp";
 
-export function getMetadata(file, uploadsUrl) {
+export function getMetadata(file, siteSettings) {
   if (!isImage(file.name)) {
     return Promise.resolve({ original_filename: file.name });
   }
@@ -11,15 +11,15 @@ export function getMetadata(file, uploadsUrl) {
     img.onload = () => resolve(img);
     img.onerror = (err) => reject(err);
     img.src = window.URL.createObjectURL(file);
-    uploadsUrl[file.name] = img.src;
   }).then((img) => {
     const ratio = Math.min(
-      Discourse.SiteSettings.max_image_width / img.width,
-      Discourse.SiteSettings.max_image_height / img.height
+      siteSettings.max_image_width / img.width,
+      siteSettings.max_image_height / img.height
     );
 
     return {
       original_filename: file.name,
+      url: img.src,
       width: img.width,
       height: img.height,
       thumbnail_width: Math.floor(img.width * ratio),

--- a/test/javascripts/lib/uploads-test.js
+++ b/test/javascripts/lib/uploads-test.js
@@ -1,30 +1,24 @@
+import { base64ToBuffer } from "discourse/plugins/discourse-encrypt/lib/base64";
 import { getMetadata } from "discourse/plugins/discourse-encrypt/lib/uploads";
 
 QUnit.module("discourse-encrypt:lib:uploadHander");
 
-let testImageBase64 =
+const TEST_IMG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
 
-test("getMetadata - image file", async (assert) => {
-  let uploadsUrl = {};
-  let file = new File([window.atob(testImageBase64)], "test.png", {
-    type: "image/png",
-    encoding: "utf-8",
-  });
+const SITE_SETTINGS = { max_image_width: 100, max_image_height: 100 };
 
-  // suppress the image onerror, it is not important
-  getMetadata(file, uploadsUrl).catch(() => null);
-  assert.ok(
-    uploadsUrl[file.name],
-    "it loads the image and adds it to uploadsUrl"
-  );
+test("getMetadata - image file", async (assert) => {
+  const file = new File([base64ToBuffer(TEST_IMG_BASE64)], "test.png", {
+    type: "image/png",
+  });
+  const data = await getMetadata(file, SITE_SETTINGS);
+  assert.equal(data.original_filename, "test.png");
+  assert.ok(data.url);
 });
 
 test("getMetadata - other file", async (assert) => {
-  let uploadsUrl = {};
-  let file = new File(["test"], "test.txt", { type: "text/plain" });
-
-  getMetadata(file, uploadsUrl).then((result) => {
-    assert.equal(result.original_filename, "test.txt");
-  });
+  const file = new File(["test"], "test.txt", { type: "text/plain" });
+  const data = await getMetadata(file, SITE_SETTINGS);
+  assert.equal(data.original_filename, "test.txt");
 });


### PR DESCRIPTION
There is no direct way to share information between the the pre-upload
and post-upload stages of the upload pipeline. To workaround this
limitation, the plugin uses a global map indexed by filename, where it
holds file information.

For certain browsers (Safari) and files (with non-ASCII characters in
filename) this method does not work because the filename read by the
browser and the one returned by the server use a different
representation and keys do not match (eg. "fi%CC%88le" vs "f%C3%AFle").
For these files, the plugin will attempt to find the information it
needs by looking up by file size.