### PR TITLE
FIX: Reject promise if identity cannot be loaded

### DIFF
--- a/assets/javascripts/discourse/initializers/hook-decrypt-topic.js
+++ b/assets/javascripts/discourse/initializers/hook-decrypt-topic.js
@@ -91,7 +91,12 @@ export default {
       api.reopenWidget("quick-access-panel", {
         setItems() {
           // Artificially delay loading until all titles are decrypted
-          return waitForPendingTitles().then(() => this._super(...arguments));
+          return waitForPendingTitles()
+            .catch(() => {
+              // eslint-disable-next-line no-console
+              console.warn("Not all encrypted titles could be decrypted");
+            })
+            .finally(() => this._super(...arguments));
         },
       });
 

--- a/assets/javascripts/lib/database.js
+++ b/assets/javascripts/lib/database.js
@@ -114,7 +114,7 @@ function loadIdentityFromLocalStorage() {
   const exported = window.localStorage.getItem(DB_NAME);
   return exported && exported !== "true"
     ? importIdentity(exported)
-    : Promise.resolve(null);
+    : Promise.reject();
 }
 
 /**
@@ -147,6 +147,8 @@ export function loadDbIdentity() {
         if (identities && identities.length > 0) {
           const identity = identities[identities.length - 1];
           resolve(identity);
+        } else {
+          reject();
         }
       };
       // eslint-disable-next-line no-unused-vars

--- a/assets/javascripts/lib/discourse.js
+++ b/assets/javascripts/lib/discourse.js
@@ -270,7 +270,7 @@ export function waitForPendingTitles() {
   return Promise.all(
     Object.values(topicTitles)
       .filter((t) => !t.result)
-      .map((t) => t.promise.catch(() => null))
+      .map((t) => t.promise)
   );
 }
 


### PR DESCRIPTION
Notification were stuck in the loading phase if the state of the browser
was invalid because the promise was never rejected on failure.