### PR TITLE
FIX: Return an empty identity if loading fails

### DIFF
--- a/assets/javascripts/lib/database.js
+++ b/assets/javascripts/lib/database.js
@@ -114,7 +114,7 @@ function loadIdentityFromLocalStorage() {
   const exported = window.localStorage.getItem(DB_NAME);
   return exported && exported !== "true"
     ? importIdentity(exported)
-    : Promise.reject();
+    : Promise.resolve(null);
 }
 
 /**
@@ -148,7 +148,7 @@ export function loadDbIdentity() {
           const identity = identities[identities.length - 1];
           resolve(identity);
         } else {
-          reject();
+          resolve(null);
         }
       };
       // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
All operations assume an empty identity will be returned instead of
an error being raised.

Follow up to 54d1f79a9eefa7e3a4e4a5b4b1303abe03ab72ed.