### PR TITLE
FIX: Add workaround for Safari's IndexedDb bug

### DIFF
--- a/assets/javascripts/lib/database.js
+++ b/assets/javascripts/lib/database.js
@@ -64,18 +64,14 @@ export function _setUserAgent(value) {
 /**
  * Warm up IndexedDB to ensure it works normally
  *
- * Used in Safari to workaround a bug. indexedDB.open hangs in Safari
- * if used immediately after page was loaded:
+ * Used in Safari 14 to work around a bug. indexedDB.open hangs in
+ * Safari if used immediately after page was loaded:
  * https://bugs.webkit.org/show_bug.cgi?id=226547
  *
  * @return {Promise<void>}
  */
 function initIndexedDb() {
-  const isSafari =
-    !!userAgent.match(/Version\/(\d+).+?Safari/) ||
-    !!userAgent.match(/(iPad|iPhone|iPod)/);
-
-  if (!isSafari) {
+  if (!userAgent.match(/Version\/14.+?Safari/)) {
     return Promise.resolve();
   }
 

--- a/assets/javascripts/lib/database.js
+++ b/assets/javascripts/lib/database.js
@@ -21,10 +21,72 @@ export let useLocalStorage = false;
 /**
  * Force usage of local storage instead of IndexedDb.
  *
+ * Used in tests
+ *
  * @param {Boolean} value Whether to use local storage.
  */
-export function setUseLocalStorage(value) {
+export function _setUseLocalStorage(value) {
   useLocalStorage = value;
+}
+
+/**
+ * IndexedDb API used to store CryptoKey objects securely
+ */
+export let indexedDb = window.indexedDB;
+
+/**
+ * Sets IndexedDb backend
+ *
+ * Used in tests
+ *
+ * @param {Object} value
+ */
+export function _setIndexedDb(value) {
+  indexedDb = value;
+}
+
+/**
+ * Browser's user agent string
+ */
+export let userAgent = window.navigator.userAgent;
+
+/**
+ * Sets browser's user agent string
+ *
+ * Used in tests
+ *
+ * @param {String} value
+ */
+export function _setUserAgent(value) {
+  userAgent = value;
+}
+
+/**
+ * Warm up IndexedDB to ensure it works normally
+ *
+ * Used in Safari to workaround a bug. indexedDB.open hangs in Safari
+ * if used immediately after page was loaded:
+ * https://bugs.webkit.org/show_bug.cgi?id=226547
+ *
+ * @return {Promise<void>}
+ */
+function initIndexedDb() {
+  const isSafari =
+    !!userAgent.match(/Version\/(\d+).+?Safari/) ||
+    !!userAgent.match(/(iPad|iPhone|iPod)/);
+
+  if (!isSafari) {
+    return Promise.resolve();
+  }
+
+  let interval;
+  return new Promise((resolve, reject) => {
+    const tryIndexedDb = () => indexedDb.databases().then(resolve, reject);
+    interval = setInterval(tryIndexedDb, 100);
+    tryIndexedDb();
+  }).finally(() => {
+    clearInterval(interval);
+  });
 }
 
 /**
@@ -35,7 +97,7 @@ export function setUseLocalStorage(value) {
  * @return {IDBOpenDBRequest}
  */
 function openDb(create) {
-  const req = window.indexedDB.open(DB_NAME, 1);
+  const req = indexedDb.open(DB_NAME, 1);
 
   req.onupgradeneeded = (evt) => {
     if (!create) {
@@ -67,18 +129,6 @@ function saveIdentityToLocalStorage(identity) {
  * @return {Promise}
  */
 export function saveDbIdentity(identity) {
-  /*
-  if (
-    !useLocalStorage &&
-    Object.values(identity).any(
-      key => key instanceof CryptoKey && key.extractable
-    )
-  ) {
-    // eslint-disable-next-line no-console
-    console.warn("Saving an extractable key into the database.", identity);
-  }
-  */
-
   if (useLocalStorage) {
     return saveIdentityToLocalStorage(identity);
   }
@@ -127,48 +177,37 @@ export function loadDbIdentity() {
     return loadIdentityFromLocalStorage();
   }
 
-  return new Promise((resolve, reject) => {
-    const req = openDb(false);
-    // eslint-disable-next-line no-unused-vars
-    req.onerror = (evt) => {
-      loadIdentityFromLocalStorage().then(resolve, reject);
-    };
-
-    req.onsuccess = (evt) => {
-      const db = evt.target.result;
-      const tx = db.transaction("keys", "readonly");
-      const st = tx.objectStore("keys");
-
-      const dataReq = st.getAll();
-      dataReq.onsuccess = (dataEvt) => {
-        const identities = dataEvt.target.result;
-        db.close();
-
-        if (identities && identities.length > 0) {
-          const identity = identities[identities.length - 1];
-          resolve(identity);
-        } else {
-          reject();
-        }
-      };
+  return initIndexedDb().then(() => {
+    return new Promise((resolve, reject) => {
+      const req = openDb(false);
       // eslint-disable-next-line no-unused-vars
-      dataReq.onerror = (dataEvt) => {
+      req.onerror = (evt) => {
         loadIdentityFromLocalStorage().then(resolve, reject);
       };
-    };
-  }).then((identity) => {
-    /*
-    if (
-      !useLocalStorage &&
-      Object.values(identity).any(
-        key => key instanceof CryptoKey && key.extractable
-      )
-    ) {
-      // eslint-disable-next-line no-console
-      console.warn("Loaded an extractable key from the database.", identity);
-    }
-    */
-    return identity;
+
+      req.onsuccess = (evt) => {
+        const db = evt.target.result;
+        const tx = db.transaction("keys", "readonly");
+        const st = tx.objectStore("keys");
+
+        const dataReq = st.getAll();
+        dataReq.onsuccess = (dataEvt) => {
+          const identities = dataEvt.target.result;
+          db.close();
+
+          if (identities && identities.length > 0) {
+            const identity = identities[identities.length - 1];
+            resolve(identity);
+          } else {
+            reject();
+          }
+        };
+        // eslint-disable-next-line no-unused-vars
+        dataReq.onerror = (dataEvt) => {
+          loadIdentityFromLocalStorage().then(resolve, reject);
+        };
+      };
+    });
   });
 }
 
@@ -181,11 +220,13 @@ export function deleteDb() {
   window.localStorage.removeItem(DB_NAME);
   window.localStorage.removeItem(DB_VERSION);
 
-  return new Promise((resolve) => {
-    const req = window.indexedDB.deleteDatabase(DB_NAME);
+  return initIndexedDb().then(() => {
+    return new Promise((resolve) => {
+      const req = indexedDb.deleteDatabase(DB_NAME);
 
-    req.onsuccess = (evt) => resolve(evt);
-    req.onerror = (evt) => resolve(evt);
-    req.onblocked = (evt) => resolve(evt);
+      req.onsuccess = (evt) => resolve(evt);
+      req.onerror = (evt) => resolve(evt);
+      req.onblocked = (evt) => resolve(evt);
+    });
   });
 }

--- a/assets/javascripts/lib/database.js
+++ b/assets/javascripts/lib/database.js
@@ -114,7 +114,7 @@ function loadIdentityFromLocalStorage() {
   const exported = window.localStorage.getItem(DB_NAME);
   return exported && exported !== "true"
     ? importIdentity(exported)
-    : Promise.resolve(null);
+    : Promise.reject();
 }
 
 /**
@@ -148,7 +148,7 @@ export function loadDbIdentity() {
           const identity = identities[identities.length - 1];
           resolve(identity);
         } else {
-          resolve(null);
+          reject();
         }
       };
       // eslint-disable-next-line no-unused-vars

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -353,8 +353,7 @@ acceptance("Encrypt", function (needs) {
     await visit("/u/eviltrout/preferences/security");
     await wait(ENCRYPT_ENABLED, () => click(".encrypt button#deactivate"));
 
-    const identity = await loadDbIdentity();
-    assert.equal(identity, null);
+    assert.rejects(loadDbIdentity());
   });
 
   test("encrypt settings visible only to allowed groups", async (assert) => {

--- a/test/javascripts/lib/database-safari-test.js
+++ b/test/javascripts/lib/database-safari-test.js
@@ -1,0 +1,46 @@
+import {
+  _setIndexedDb,
+  _setUserAgent,
+  deleteDb,
+  loadDbIdentity,
+} from "discourse/plugins/discourse-encrypt/lib/database";
+import { test } from "qunit";
+import { Promise } from "rsvp";
+
+let indexedDbCalls = 0;
+
+QUnit.module("discourse-encrypt:lib:database-safari", {
+  beforeEach() {
+    indexedDbCalls = 0;
+
+    _setIndexedDb({
+      open(name, version) {
+        return window.indexedDB.open(name, version);
+      },
+
+      databases() {
+        return indexedDbCalls++ > 3
+          ? window.indexedDB.databases()
+          : new Promise(() => {});
+      },
+
+      deleteDatabase(name) {
+        indexedDbCalls++;
+        return window.indexedDB.deleteDatabase(name);
+      },
+    });
+
+    _setUserAgent("iPhone");
+  },
+
+  afterEach() {
+    _setIndexedDb(window.indexedDB);
+    _setUserAgent(window.navigator.userAgent);
+  },
+});
+
+test("IndexedDB is initialized in Safari", async (assert) => {
+  await deleteDb();
+  assert.rejects(loadDbIdentity());
+  assert.ok(indexedDbCalls > 0);
+});

--- a/test/javascripts/lib/database-test.js
+++ b/test/javascripts/lib/database-test.js
@@ -1,16 +1,17 @@
-import { generateIdentity } from "discourse/plugins/discourse-encrypt/lib/protocol";
 import {
   DB_NAME,
+  _setUseLocalStorage,
   deleteDb,
   loadDbIdentity,
   saveDbIdentity,
-  setUseLocalStorage,
 } from "discourse/plugins/discourse-encrypt/lib/database";
+import { generateIdentity } from "discourse/plugins/discourse-encrypt/lib/protocol";
+import { test } from "qunit";
 
 QUnit.module("discourse-encrypt:lib:database");
 
 test("IndexedDB backend", async (assert) => {
-  setUseLocalStorage(false);
+  _setUseLocalStorage(false);
   await deleteDb();
 
   assert.rejects(loadDbIdentity());
@@ -31,7 +32,7 @@ test("IndexedDB backend", async (assert) => {
 });
 
 test("Web Storage (localStorage) backend", async (assert) => {
-  setUseLocalStorage(true);
+  _setUseLocalStorage(true);
   await deleteDb();
 
   assert.rejects(loadDbIdentity());

--- a/test/javascripts/lib/database-test.js
+++ b/test/javascripts/lib/database-test.js
@@ -13,13 +13,12 @@ test("IndexedDB backend", async (assert) => {
   setUseLocalStorage(false);
   await deleteDb();
 
-  let identity = await loadDbIdentity();
-  assert.equal(identity, null);
+  assert.rejects(loadDbIdentity());
 
   await generateIdentity().then((id) => saveDbIdentity(id));
   assert.ok(window.localStorage.getItem(DB_NAME));
 
-  identity = await loadDbIdentity();
+  const identity = await loadDbIdentity();
   assert.ok(identity.encryptPublic instanceof CryptoKey);
   assert.ok(identity.encryptPrivate instanceof CryptoKey);
   assert.ok(identity.signPublic instanceof CryptoKey);
@@ -27,8 +26,7 @@ test("IndexedDB backend", async (assert) => {
 
   await deleteDb();
 
-  identity = await loadDbIdentity();
-  assert.equal(identity, null);
+  assert.rejects(loadDbIdentity());
   assert.equal(window.localStorage.getItem(DB_NAME), null);
 });
 
@@ -36,13 +34,12 @@ test("Web Storage (localStorage) backend", async (assert) => {
   setUseLocalStorage(true);
   await deleteDb();
 
-  let identity = await loadDbIdentity();
-  assert.equal(identity, null);
+  assert.rejects(loadDbIdentity());
 
   await generateIdentity().then((id) => saveDbIdentity(id));
   assert.ok(window.localStorage.getItem(DB_NAME));
 
-  identity = await loadDbIdentity();
+  const identity = await loadDbIdentity();
   assert.ok(identity.encryptPublic instanceof CryptoKey);
   assert.ok(identity.encryptPrivate instanceof CryptoKey);
   assert.ok(identity.signPublic instanceof CryptoKey);
@@ -50,7 +47,6 @@ test("Web Storage (localStorage) backend", async (assert) => {
 
   await deleteDb();
 
-  identity = await loadDbIdentity();
-  assert.equal(identity, null);
+  assert.rejects(loadDbIdentity());
   assert.equal(window.localStorage.getItem(DB_NAME), null);
 });


### PR DESCRIPTION
In Safari 14, indexedDB.open hangs if used immediately after page was
loaded. Performing other operations as a warm up works around this bug.