### PR TITLE
FIX: Show activation modal if identity is missing

### DIFF
--- a/assets/javascripts/discourse/controllers/activate-encrypt.js
+++ b/assets/javascripts/discourse/controllers/activate-encrypt.js
@@ -5,26 +5,28 @@ import I18n from "I18n";
 
 export default Controller.extend(ModalFunctionality, {
   onShow() {
-    const models = this.models || [];
-    models.push(this.model);
+    const widgets = this.widgets || [];
+    widgets.push(this.model.widget);
 
     this.setProperties({
-      models: models,
+      widgets,
       passphrase: "",
       error: "",
     });
   },
 
   onClose() {
-    const models = this.models || [];
-    models.forEach((model) => {
-      model.state.encryptState = "error";
-      model.state.error = I18n.t(
+    if (!this.widgets) {
+      return;
+    }
+
+    this.widgets.forEach((widget) => {
+      widget.state.encryptState = "error";
+      widget.state.error = I18n.t(
         "encrypt.preferences.status_enabled_but_inactive"
       );
-      model.scheduleRerender();
+      widget.scheduleRerender();
     });
-    this.set("models", null);
   },
 
   actions: {
@@ -34,12 +36,11 @@ export default Controller.extend(ModalFunctionality, {
       return activateEncrypt(this.currentUser, this.passphrase)
         .then(() => {
           this.appEvents.trigger("encrypt:status-changed");
-          this.models.forEach((model) => {
-            model.state.decrypting = true;
-            model.state.decrypted = false;
-            model.scheduleRerender();
+          this.widgets.forEach((widget) => {
+            widget.state.encryptState = "decrypting";
+            widget.scheduleRerender();
           });
-          this.set("models", null);
+          this.set("widgets", null);
           this.send("closeModal");
         })
         .catch(() =>

--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -368,13 +368,7 @@ export default {
         state.ciphertext = ciphertext;
 
         getIdentity()
-          .then((identity) => {
-            if (!identity) {
-              // Absence of private key means user did not activate encryption.
-              showModal("activate-encrypt", { model: this });
-              return;
-            }
-
+          .then(() => {
             getTopicKey(topicId)
               .then((key) => {
                 decrypt(key, ciphertext)
@@ -435,9 +429,7 @@ export default {
               });
           })
           .catch(() => {
-            state.encryptState = "error";
-            state.error = I18n.t("encrypt.invalid_identity");
-            this.scheduleRerender();
+            showModal("activate-encrypt", { model: this });
           });
       }
 

--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -429,7 +429,7 @@ export default {
               });
           })
           .catch(() => {
-            showModal("activate-encrypt", { model: this });
+            showModal("activate-encrypt", { model: { widget: this } });
           });
       }
 

--- a/assets/javascripts/lib/database.js
+++ b/assets/javascripts/lib/database.js
@@ -1,3 +1,4 @@
+import { isTesting } from "discourse-common/config/environment";
 import {
   exportIdentity,
   importIdentity,
@@ -25,11 +26,13 @@ export let useLocalStorage = false;
 /**
  * Force usage of local storage instead of IndexedDb.
  *
- * Used in tests
- *
  * @param {Boolean} value Whether to use local storage.
  */
-export function _setUseLocalStorage(value) {
+export function setUseLocalStorage(value) {
+  if (!isTesting()) {
+    throw new Error("`setUseLocalStorage` can be called from tests only");
+  }
+
   useLocalStorage = value;
 }
 
@@ -41,11 +44,13 @@ export let indexedDb = window.indexedDB;
 /**
  * Sets IndexedDb backend
  *
- * Used in tests
- *
  * @param {Object} value
  */
-export function _setIndexedDb(value) {
+export function setIndexedDb(value) {
+  if (!isTesting()) {
+    throw new Error("`setIndexedDb` can be called from tests only");
+  }
+
   indexedDb = value;
 }
 
@@ -57,11 +62,13 @@ export let userAgent = window.navigator.userAgent;
 /**
  * Sets browser's user agent string
  *
- * Used in tests
- *
  * @param {String} value
  */
-export function _setUserAgent(value) {
+export function setUserAgent(value) {
+  if (!isTesting()) {
+    throw new Error("`setUserAgent` can be called from tests only");
+  }
+
   userAgent = value;
 }
 

--- a/assets/javascripts/lib/discourse.js
+++ b/assets/javascripts/lib/discourse.js
@@ -44,17 +44,17 @@ let userIdentity;
 /**
  * @var {Object} userIdentities Cached user identities.
  */
-const userIdentities = getCaseInsensitiveObj();
+let userIdentities = getCaseInsensitiveObj();
 
 /**
  * @var {Object} topicKeys Dictionary of all topic keys (topic_id => key).
  */
-const topicKeys = {};
+let topicKeys = {};
 
 /**
  * @var {Object} topicTitles Dictionary of all topic title objects (topic_id => TopicTitle).
  */
-const topicTitles = {};
+let topicTitles = {};
 
 class TopicTitle {
   constructor(topicId, encrypted) {
@@ -72,6 +72,15 @@ class TopicTitle {
 
     return this._promise;
   }
+}
+
+/**
+ * Resets plugin state
+ *
+ * Used in tests.
+ */
+export function _reset() {
+  userIdentity = null;
 }
 
 /**

--- a/assets/javascripts/lib/discourse.js
+++ b/assets/javascripts/lib/discourse.js
@@ -1,3 +1,4 @@
+import { isTesting } from "discourse-common/config/environment";
 import { ajax } from "discourse/lib/ajax";
 import {
   DB_NAME,
@@ -79,7 +80,11 @@ class TopicTitle {
  *
  * Used in tests.
  */
-export function _reset() {
+export function resetUserIdentity() {
+  if (!isTesting()) {
+    throw new Error("`resetUserIdentity` can be called from tests only");
+  }
+
   userIdentity = null;
 }
 

--- a/assets/javascripts/lib/discourse.js
+++ b/assets/javascripts/lib/discourse.js
@@ -45,17 +45,17 @@ let userIdentity;
 /**
  * @var {Object} userIdentities Cached user identities.
  */
-let userIdentities = getCaseInsensitiveObj();
+const userIdentities = getCaseInsensitiveObj();
 
 /**
  * @var {Object} topicKeys Dictionary of all topic keys (topic_id => key).
  */
-let topicKeys = {};
+const topicKeys = {};
 
 /**
  * @var {Object} topicTitles Dictionary of all topic title objects (topic_id => TopicTitle).
  */
-let topicTitles = {};
+const topicTitles = {};
 
 class TopicTitle {
   constructor(topicId, encrypted) {
@@ -76,9 +76,7 @@ class TopicTitle {
 }
 
 /**
- * Resets plugin state
- *
- * Used in tests.
+ * Resets loaded user identity
  */
 export function resetUserIdentity() {
   if (!isTesting()) {

--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -42,6 +42,12 @@ pre.exported-key-pair {
   word-break: break-all;
 }
 
+.modal.activate-encrypt-modal {
+  input#passphrase {
+    width: 100%;
+  }
+}
+
 .modal .modal-body .paper-key {
   font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono",
     "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace,

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -10,6 +10,7 @@ import EncryptLibDiscourse, {
   ENCRYPT_ACTIVE,
   ENCRYPT_DISABLED,
   ENCRYPT_ENABLED,
+  _reset,
   getEncryptionStatus,
   getIdentity,
 } from "discourse/plugins/discourse-encrypt/lib/discourse";
@@ -19,6 +20,7 @@ import {
   exportKey,
   generateIdentity,
   generateKey,
+  importIdentity,
 } from "discourse/plugins/discourse-encrypt/lib/protocol";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { default as userFixtures } from "discourse/tests/fixtures/user-fixtures";
@@ -26,6 +28,7 @@ import { parsePostData } from "discourse/tests/helpers/create-pretender";
 import {
   acceptance,
   count,
+  exists,
   query,
   queryAll,
   updateCurrentUser,
@@ -171,6 +174,8 @@ acceptance("Encrypt", function (needs) {
       }
       return this.send_(...arguments);
     };
+
+    _reset();
   });
 
   needs.hooks.afterEach(() => {
@@ -353,7 +358,260 @@ acceptance("Encrypt", function (needs) {
     assert.rejects(loadDbIdentity());
   });
 
-  test("viewing encrypted topic works", async (assert) => {
+  test("viewing encrypted topic works when just enabled", async (assert) => {
+    await setEncryptionStatus(ENCRYPT_ENABLED);
+    globalAssert = assert;
+
+    const identities = JSON.parse(User.current().encrypt_private);
+    const identity = await importIdentity(identities["passphrase"], PASSPHRASE);
+    const topicKey = await generateKey();
+    const exportedTopicKey = await exportKey(topicKey, identity.encryptPublic);
+    const encryptedTitle = await encrypt(topicKey, { raw: "Top Secret Title" });
+    const encryptedRaw = await encrypt(topicKey, { raw: "Top Secret Post" });
+
+    server.get("/t/42.json", () => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        {
+          post_stream: {
+            posts: [
+              {
+                id: 42,
+                name: null,
+                username: "bar",
+                avatar_template:
+                  "/letter_avatar_proxy/v4/letter/b/000000/{size}.png",
+                created_at: "2020-01-01T12:00:00.000Z",
+                cooked:
+                  "<p>This is a secret message with end to end encryption. To view it, you must be invited to this topic.</p>",
+                post_number: 1,
+                post_type: 1,
+                updated_at: "2020-01-01T12:00:00.000Z",
+                reply_count: 0,
+                reply_to_post_number: null,
+                quote_count: 0,
+                incoming_link_count: 0,
+                reads: 2,
+                readers_count: 1,
+                score: 0.4,
+                yours: false,
+                topic_id: 42,
+                topic_slug: "a-secret-message",
+                display_username: null,
+                primary_group_name: null,
+                primary_group_flair_url: null,
+                primary_group_flair_bg_color: null,
+                primary_group_flair_color: null,
+                version: 1,
+                can_edit: true,
+                can_delete: false,
+                can_recover: false,
+                can_wiki: true,
+                read: true,
+                user_title: null,
+                title_is_group: false,
+                bookmarked: false,
+                actions_summary: [
+                  {
+                    id: 2,
+                    can_act: true,
+                  },
+                  {
+                    id: 3,
+                    can_act: true,
+                  },
+                  {
+                    id: 4,
+                    can_act: true,
+                  },
+                  {
+                    id: 8,
+                    can_act: true,
+                  },
+                  {
+                    id: 6,
+                    can_act: true,
+                  },
+                  {
+                    id: 7,
+                    can_act: true,
+                  },
+                ],
+                moderator: false,
+                admin: true,
+                staff: true,
+                user_id: 2,
+                hidden: false,
+                trust_level: 0,
+                deleted_at: null,
+                user_deleted: false,
+                edit_reason: null,
+                can_view_edit_history: true,
+                wiki: false,
+                reviewable_id: 0,
+                reviewable_score_count: 0,
+                reviewable_score_pending_count: 0,
+                encrypted_raw: encryptedRaw,
+              },
+            ],
+            stream: [42],
+          },
+          timeline_lookup: [[1, 0]],
+          related_messages: [],
+          suggested_topics: [],
+          id: 42,
+          title: "A secret message",
+          fancy_title: "A secret message",
+          posts_count: 1,
+          created_at: "2020-01-01T12:00:00.000Z",
+          views: 2,
+          reply_count: 0,
+          like_count: 0,
+          last_posted_at: "2020-01-01T12:00:00.000Z",
+          visible: true,
+          closed: false,
+          archived: false,
+          has_summary: false,
+          archetype: "private_message",
+          slug: "a-secret-message",
+          category_id: null,
+          word_count: 16,
+          deleted_at: null,
+          user_id: 2,
+          featured_link: null,
+          pinned_globally: false,
+          pinned_at: null,
+          pinned_until: null,
+          image_url: null,
+          slow_mode_seconds: 0,
+          draft: null,
+          draft_key: "topic_42",
+          draft_sequence: 0,
+          posted: false,
+          unpinned: null,
+          pinned: false,
+          current_post_number: 1,
+          highest_post_number: 1,
+          last_read_post_number: 1,
+          last_read_post_id: 42,
+          deleted_by: null,
+          has_deleted: false,
+          actions_summary: [
+            {
+              id: 4,
+              count: 0,
+              hidden: false,
+              can_act: true,
+            },
+            {
+              id: 8,
+              count: 0,
+              hidden: false,
+              can_act: true,
+            },
+            {
+              id: 7,
+              count: 0,
+              hidden: false,
+              can_act: true,
+            },
+          ],
+          chunk_size: 20,
+          bookmarked: false,
+          message_archived: false,
+          topic_timer: null,
+          message_bus_last_id: 3,
+          participant_count: 1,
+          pm_with_non_human_user: false,
+          queued_posts_count: 0,
+          show_read_indicator: false,
+          requested_group_name: null,
+          thumbnails: null,
+          slow_mode_enabled_until: null,
+          encrypted_title: encryptedTitle,
+          topic_key: exportedTopicKey,
+          details: {
+            can_edit: true,
+            notification_level: 3,
+            notifications_reason_id: 2,
+            can_move_posts: true,
+            can_delete: true,
+            can_remove_allowed_users: true,
+            can_invite_to: true,
+            can_invite_via_email: true,
+            can_create_post: true,
+            can_reply_as_new_topic: true,
+            can_flag_topic: true,
+            can_convert_topic: true,
+            can_review_topic: true,
+            can_close_topic: true,
+            can_archive_topic: true,
+            can_split_merge_topic: true,
+            can_edit_staff_notes: true,
+            can_toggle_topic_visibility: true,
+            can_pin_unpin_topic: true,
+            can_moderate_category: true,
+            can_remove_self_id: 1,
+            participants: [
+              {
+                id: 2,
+                username: "bar",
+                name: null,
+                avatar_template:
+                  "/letter_avatar_proxy/v4/letter/b/000000/{size}.png",
+                post_count: 1,
+                primary_group_name: null,
+                primary_group_flair_url: null,
+                primary_group_flair_color: null,
+                primary_group_flair_bg_color: null,
+                admin: true,
+                trust_level: 0,
+              },
+            ],
+            allowed_users: [
+              {
+                id: 1,
+                username: "foo",
+                name: null,
+                avatar_template:
+                  "/letter_avatar_proxy/v4/letter/f/000000/{size}.png",
+              },
+              {
+                id: 2,
+                username: "bar",
+                name: null,
+                avatar_template:
+                  "/letter_avatar_proxy/v4/letter/b/000000/{size}.png",
+              },
+            ],
+            created_by: {
+              id: 2,
+              username: "bar",
+              name: null,
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/b/000000/{size}.png",
+            },
+            last_poster: {
+              id: 2,
+              username: "bar",
+              name: null,
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/b/000000/{size}.png",
+            },
+            allowed_groups: [],
+          },
+          pending_posts: [],
+        },
+      ];
+    });
+
+    await visit("/t/a-secret-message/42");
+    await visit("/t/a-secret-message/42"); // wait for re-render
+    assert.ok(exists(".modal.activate-encrypt-modal"));
+  });
+
+  test("viewing encrypted topic works when active", async (assert) => {
     await setEncryptionStatus(ENCRYPT_ACTIVE);
     globalAssert = assert;
 

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -10,9 +10,9 @@ import EncryptLibDiscourse, {
   ENCRYPT_ACTIVE,
   ENCRYPT_DISABLED,
   ENCRYPT_ENABLED,
-  _reset,
   getEncryptionStatus,
   getIdentity,
+  resetUserIdentity,
 } from "discourse/plugins/discourse-encrypt/lib/discourse";
 import {
   encrypt,
@@ -175,7 +175,7 @@ acceptance("Encrypt", function (needs) {
       return this.send_(...arguments);
     };
 
-    _reset();
+    resetUserIdentity();
   });
 
   needs.hooks.afterEach(() => {

--- a/test/javascripts/lib/database-safari-test.js
+++ b/test/javascripts/lib/database-safari-test.js
@@ -1,8 +1,8 @@
 import {
-  _setIndexedDb,
-  _setUserAgent,
   deleteDb,
   loadDbIdentity,
+  setIndexedDb,
+  setUserAgent,
 } from "discourse/plugins/discourse-encrypt/lib/database";
 import { test } from "qunit";
 import { Promise } from "rsvp";
@@ -13,7 +13,7 @@ QUnit.module("discourse-encrypt:lib:database-safari", {
   beforeEach() {
     indexedDbCalls = 0;
 
-    _setIndexedDb({
+    setIndexedDb({
       open(name, version) {
         return window.indexedDB.open(name, version);
       },
@@ -30,12 +30,12 @@ QUnit.module("discourse-encrypt:lib:database-safari", {
       },
     });
 
-    _setUserAgent("iPhone");
+    setUserAgent("iPhone");
   },
 
   afterEach() {
-    _setIndexedDb(window.indexedDB);
-    _setUserAgent(window.navigator.userAgent);
+    setIndexedDb(window.indexedDB);
+    setUserAgent(window.navigator.userAgent);
   },
 });
 

--- a/test/javascripts/lib/database-test.js
+++ b/test/javascripts/lib/database-test.js
@@ -1,9 +1,9 @@
 import {
   DB_NAME,
-  _setUseLocalStorage,
   deleteDb,
   loadDbIdentity,
   saveDbIdentity,
+  setUseLocalStorage,
 } from "discourse/plugins/discourse-encrypt/lib/database";
 import { generateIdentity } from "discourse/plugins/discourse-encrypt/lib/protocol";
 import { test } from "qunit";
@@ -11,7 +11,7 @@ import { test } from "qunit";
 QUnit.module("discourse-encrypt:lib:database");
 
 test("IndexedDB backend", async (assert) => {
-  _setUseLocalStorage(false);
+  setUseLocalStorage(false);
   await deleteDb();
 
   assert.rejects(loadDbIdentity());
@@ -32,7 +32,7 @@ test("IndexedDB backend", async (assert) => {
 });
 
 test("Web Storage (localStorage) backend", async (assert) => {
-  _setUseLocalStorage(true);
+  setUseLocalStorage(true);
   await deleteDb();
 
   assert.rejects(loadDbIdentity());


### PR DESCRIPTION
A user's identity was missing if they had encryption enabled, but the
current device was not activated. To make it easy to use, the user was
prompted to activate the device when they navigated to an encrypted
topic. This behavior changed when `getIdentity` started to return a
rejected promise when user has no identity (it used to return an empty
identity).