### PR TITLE
FIX: Decrypt titles from generic elements first

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-topics.js
+++ b/assets/javascripts/discourse/initializers/decrypt-topics.js
@@ -168,6 +168,10 @@ export default {
   },
 
   decryptTitles() {
+    decryptElements("a.topic-link[data-topic-id]", "span");
+    decryptElements("a.topic-link[data-topic-id]", null, { addIcon: true });
+    decryptElements("a.raw-topic-link[data-topic-id]", null, { addIcon: true });
+
     // Title in site header
     decryptElements("h1.header-title", ".topic-link", { replaceIcon: true });
 
@@ -180,10 +184,6 @@ export default {
       ".title",
       { addIcon: true }
     );
-
-    decryptElements("a.topic-link[data-topic-id]", "span");
-    decryptElements("a.topic-link[data-topic-id]", null, { addIcon: true });
-    decryptElements("a.raw-topic-link[data-topic-id]", null, { addIcon: true });
   },
 
   decryptDocTitle(data) {


### PR DESCRIPTION
There is a list of CSS selectors that match most of the elements that
contain topic titles. The generic ones can overlap with the more
specific ones. It is best to decrypt the elements matched by generic
ones first and then let the specific ones override them.

This commit fixes the bug that shows two secret icons in header.