### PR TITLE
FIX: Ensure post_search_data is present

### DIFF
--- a/lib/encrypted_search.rb
+++ b/lib/encrypted_search.rb
@@ -11,6 +11,7 @@ class EncryptedSearch < Search
       .includes(topic: :encrypted_topics_data)
       .where.not(encrypted_topics_data: { title: nil })
       .where(post_type: Topic.visible_post_types(@guardian.user))
+      .where('post_search_data.private_message')
       .limit(limit)
   end
 


### PR DESCRIPTION
It is not technically required, but the serializer needs it to generate
the blurb.