### PR TITLE
FIX: Do not download and decrypt same file twice

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -150,7 +150,8 @@ function resolveShortUrlElement($el) {
       return;
     }
 
-    $el.on("click", () => {
+    $el.off("click.discourse-encrypt");
+    $el.on("click.discourse-encrypt", () => {
       downloadEncryptedFile(url, keyPromise, { type: $el.data("type") }).then(
         (file) => {
           const a = document.createElement("a");


### PR DESCRIPTION
The click handler that downloads and decrypts the file was registered
every time the post was processed and that can happen multiple times.