### PR TITLE
FIX: Include only PMs that can be read in search

### DIFF
--- a/lib/encrypted_search.rb
+++ b/lib/encrypted_search.rb
@@ -10,6 +10,8 @@ class EncryptedSearch < Search
     Post
       .includes(topic: :encrypted_topics_data)
       .where.not(encrypted_topics_data: { title: nil })
+      .joins(topic: :encrypted_topics_users)
+      .where(encrypted_topics_users: { user_id: @guardian.user&.id })
       .where(post_type: Topic.visible_post_types(@guardian.user))
       .where('post_search_data.private_message')
       .limit(limit)

--- a/spec/requests/encrypt_controller_spec.rb
+++ b/spec/requests/encrypt_controller_spec.rb
@@ -144,6 +144,19 @@ describe DiscourseEncrypt::EncryptController do
       expect(response.status).to eq(403)
     end
 
+    it 'does not fetch posts user cannot read' do
+      admin = Fabricate(:admin)
+      sign_in(admin)
+
+      topic = Fabricate(:encrypt_topic, topic_allowed_users: [ Fabricate.build(:topic_allowed_user, user: admin) ])
+      Fabricate(:post, topic: topic)
+
+      get '/encrypt/posts.json'
+      expect(response.status).to eq(200)
+      expect(response.parsed_body['topics'].size).to eq(1)
+      expect(response.parsed_body['posts'].size).to eq(1)
+    end
+
     it 'fetches posts' do
       sign_in(user)
 


### PR DESCRIPTION
It used to include all PMs that user has access to, even if they did not
have a key for the topic.