### PR TITLE
FIX: Search cache can contain only first posts

### DIFF
--- a/lib/encrypted_search.rb
+++ b/lib/encrypted_search.rb
@@ -12,6 +12,7 @@ class EncryptedSearch < Search
       .where.not(encrypted_topics_data: { title: nil })
       .joins(topic: :encrypted_topics_users)
       .where(encrypted_topics_users: { user_id: @guardian.user&.id })
+      .where(post_number: 1)
       .where(post_type: Topic.visible_post_types(@guardian.user))
       .where('post_search_data.private_message')
       .limit(limit)

--- a/spec/requests/encrypt_controller_spec.rb
+++ b/spec/requests/encrypt_controller_spec.rb
@@ -150,6 +150,7 @@ describe DiscourseEncrypt::EncryptController do
 
       topic = Fabricate(:encrypt_topic, topic_allowed_users: [ Fabricate.build(:topic_allowed_user, user: admin) ])
       Fabricate(:post, topic: topic)
+      Fabricate(:post, topic: topic)
 
       get '/encrypt/posts.json'
       expect(response.status).to eq(200)


### PR DESCRIPTION
The search uses only topic information (i.e. title) which means that the
first post is enough. This way, the cache can contain information about
more topics.