### PR TITLE
FIX: Always decrypt topic title

### DIFF
--- a/assets/javascripts/discourse/initializers/add-search-results.js
+++ b/assets/javascripts/discourse/initializers/add-search-results.js
@@ -40,6 +40,7 @@ function getOrFetchCache(session) {
       const promises = [];
 
       result.posts.forEach((post) => {
+        post.topic_title_headline = null;
         addCacheItem(session, "posts", post);
       });
 


### PR DESCRIPTION
When use_pg_headlines_for_excerpt is enabled, the topic_title_headline
property of the post model is used instead of topic.fancy_title. This
means the topic titles were not decrypted in search results.