### PR TITLE
FIX: Anonymous users cannot encrypt PMs

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -120,6 +120,7 @@ after_initialize do
 
   add_to_class(:guardian, :can_encrypt?) do
     return false if !SiteSetting.encrypt_enabled?
+    return false if !authenticated?
     return true if SiteSetting.encrypt_groups.empty?
 
     encrypt_groups = SiteSetting.encrypt_groups.split('|').map(&:downcase)


### PR DESCRIPTION
The can_encrypt? method returned true for unauthenticated users if
encrypt_groups was blank. Otherwise, it was raising an error because groups method
was
undefined.