### PR TITLE
DEV: support changes in user bookmarks in core

### DIFF
--- a/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
+++ b/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
@@ -13,6 +13,45 @@ import { Promise } from "rsvp";
 
 const CACHE_KEY = "discourse-encrypt-bookmark-cache";
 
+function decryptBookmarks(session, response, query, username) {
+  if (!query) {
+    saveBookmarksResponse(session, response);
+    return response;
+  }
+
+  let cachePromise = Promise.resolve();
+  if (!session.get(CACHE_KEY)) {
+    const url = `/u/${username}/bookmarks.json`;
+    cachePromise = ajax(url).then((resp) =>
+      saveBookmarksResponse(session, resp)
+    );
+  }
+
+  return cachePromise.then(() => {
+    const bookmarkIds = new Set();
+    response?.user_bookmark_list?.bookmarks?.forEach((bookmark) => {
+      bookmarkIds.add(bookmark.id);
+    });
+
+    const cache = session.get(CACHE_KEY);
+    cache.forEach((bookmark) => {
+      if (
+        bookmark.title.toLowerCase().includes(query.toLowerCase())
+      ) {
+        if (!response?.user_bookmark_list?.bookmarks) {
+          response = { user_bookmark_list: { bookmarks: [] } };
+        }
+
+        if (!bookmarkIds.has(bookmark.id)) {
+          bookmarkIds.add(bookmark.id);
+          response.user_bookmark_list.bookmarks.push(bookmark);
+        }
+      }
+    });
+    return response;
+  });
+}
+
 function saveBookmarksResponse(session, response) {
   if (!response?.user_bookmark_list?.bookmarks) {
     return Promise.resolve();
@@ -132,42 +171,7 @@ export default {
 
         loadItems(params) {
           return this._super(...arguments).then((response) => {
-            if (!params.q) {
-              saveBookmarksResponse(session, response);
-              return response;
-            }
-
-            let cachePromise = Promise.resolve();
-            if (!session.get(CACHE_KEY)) {
-              const url = `/u/${currentUser.username}/bookmarks.json`;
-              cachePromise = ajax(url).then((resp) =>
-                saveBookmarksResponse(session, resp)
-              );
-            }
-
-            return cachePromise.then(() => {
-              const bookmarkIds = new Set();
-              response?.user_bookmark_list?.bookmarks?.forEach((bookmark) => {
-                bookmarkIds.add(bookmark.id);
-              });
-
-              const cache = session.get(CACHE_KEY);
-              cache.forEach((bookmark) => {
-                if (
-                  bookmark.title.toLowerCase().includes(params.q.toLowerCase())
-                ) {
-                  if (!response?.user_bookmark_list?.bookmarks) {
-                    response = { user_bookmark_list: { bookmarks: [] } };
-                  }
-
-                  if (!bookmarkIds.has(bookmark.id)) {
-                    bookmarkIds.add(bookmark.id);
-                    response.user_bookmark_list.bookmarks.push(bookmark);
-                  }
-                }
-              });
-              return response;
-            });
+            return decryptBookmarks(session, response, params.q, currentUser.username);
           });
         },
       });

--- a/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
+++ b/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
@@ -13,7 +13,7 @@ import { Promise } from "rsvp";
 
 const CACHE_KEY = "discourse-encrypt-bookmark-cache";
 
-function decryptBookmarks(session, response, query, username) {
+function addEncryptedBookmarksFromCache(session, response, query, username) {
   if (!query) {
     saveBookmarksResponse(session, response);
     return response;
@@ -170,7 +170,7 @@ export default {
 
         loadItems(params) {
           return this._super(...arguments).then((response) => {
-            return decryptBookmarks(
+            return addEncryptedBookmarksFromCache(
               session,
               response,
               params.q,
@@ -185,7 +185,7 @@ export default {
 
         _loadBookmarks(params) {
           return this._super(...arguments).then((response) => {
-            return decryptBookmarks(
+            return addEncryptedBookmarksFromCache(
               session,
               response,
               params.q,

--- a/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
+++ b/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
@@ -166,10 +166,21 @@ export default {
         },
       });
 
+      // this can be removed in v2.8.0.beta7
       api.modifyClass("model:bookmark", {
         pluginId: "fetch-encrypt-keys",
 
         loadItems(params) {
+          return this._super(...arguments).then((response) => {
+            return decryptBookmarks(session, response, params.q, currentUser.username);
+          });
+        },
+      });
+
+      api.modifyClass("route:user-activity-bookmarks", {
+        pluginId: "fetch-encrypt-keys",
+
+        _loadBookmarks(params) {
           return this._super(...arguments).then((response) => {
             return decryptBookmarks(session, response, params.q, currentUser.username);
           });

--- a/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
+++ b/assets/javascripts/discourse/initializers/fetch-encrypt-keys.js
@@ -35,9 +35,7 @@ function decryptBookmarks(session, response, query, username) {
 
     const cache = session.get(CACHE_KEY);
     cache.forEach((bookmark) => {
-      if (
-        bookmark.title.toLowerCase().includes(query.toLowerCase())
-      ) {
+      if (bookmark.title.toLowerCase().includes(query.toLowerCase())) {
         if (!response?.user_bookmark_list?.bookmarks) {
           response = { user_bookmark_list: { bookmarks: [] } };
         }
@@ -172,7 +170,12 @@ export default {
 
         loadItems(params) {
           return this._super(...arguments).then((response) => {
-            return decryptBookmarks(session, response, params.q, currentUser.username);
+            return decryptBookmarks(
+              session,
+              response,
+              params.q,
+              currentUser.username
+            );
           });
         },
       });
@@ -182,7 +185,12 @@ export default {
 
         _loadBookmarks(params) {
           return this._super(...arguments).then((response) => {
-            return decryptBookmarks(session, response, params.q, currentUser.username);
+            return decryptBookmarks(
+              session,
+              response,
+              params.q,
+              currentUser.username
+            );
           });
         },
       });


### PR DESCRIPTION
This PR aim to support changes that'll be made by [FIX: empty state message on the user bookmarks page](https://github.com/discourse/discourse/pull/14257). That PR moves the method for loading bookmarks from the model to the route. There is a failed test in that PR that shows that it breaks the discourse-encrypt plugin.

The changes supported in backward compatible manner:
- we can merge this PR firstly
- then we can merge [FIX: empty state message on the user bookmarks page](https://github.com/discourse/discourse/pull/14257) in core
- after that, we can remove code that modifies the bookmark model from Discourse Encrypt
