### PR TITLE
DEV: Fix `linkSeenHashtags` args deprecation

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -202,8 +202,6 @@ function resolveShortUrlElement($el) {
 }
 
 function postProcessPost(siteSettings, topicId, post) {
-  const $post = $(post);
-
   // Paint mentions
   const unseenMentions = linkSeenMentions(post, siteSettings);
   if (unseenMentions.length > 0) {
@@ -218,13 +216,13 @@ function postProcessPost(siteSettings, topicId, post) {
   }
 
   // Paint category and tag hashtags
-  const unseenTagHashtags = linkSeenHashtags($post);
+  const unseenTagHashtags = linkSeenHashtags(post);
   if (unseenTagHashtags.length > 0) {
     if (!hashtagsQueue) {
       hashtagsQueue = new DebouncedQueue(500, fetchUnseenHashtags);
     }
     hashtagsQueue.push(...unseenTagHashtags).then(() => {
-      linkSeenHashtags($post);
+      linkSeenHashtags(post);
     });
   }
 


### PR DESCRIPTION
```
Deprecation notice: linkSeenHashtags now expects a DOM node as first parameter (deprecated since Discourse 2.8.0.beta7)
```