### PR TITLE
FIX: ensure bots can always send encrypted messages

### DIFF
--- a/lib/encrypted_post_creator.rb
+++ b/lib/encrypted_post_creator.rb
@@ -57,6 +57,7 @@ class EncryptedPostCreator < PostCreator
 
   def users
     @users ||= User
+      .human_users
       .includes(:user_encryption_key)
       .where(username_lower: (@opts[:target_usernames].split(',') << @user.username).map(&:downcase))
       .to_a


### PR DESCRIPTION
In 1492adbc76d we ensured we created a topic key for all the participants
in the PM. However, since the bots (like the system user) have no way to
generate an encryption key, they can't send encrypted messages anymore.

This bypass the check for bots as we don't really care if they can read
the encrypted message. This allow to programmatically send encrypted message
as the system user for example.