### PR TITLE
DEV: remove unused field from an acceptance test

### DIFF
--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -1176,8 +1176,6 @@ acceptance("Encrypt", function (needs) {
           { "Content-Type": "application/json" },
           {
             bookmarks: [],
-            no_results_help:
-              "No bookmarks found with the provided search query.",
           },
         ];
       }


### PR DESCRIPTION
We don't consume this field on the client, starting from https://github.com/discourse/discourse/pull/14311. The server will stop returning it in response, starting from https://github.com/discourse/discourse/pull/15220.
