### PR TITLE
FIX: remove move to button for encrypted messages

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-topics.js
+++ b/assets/javascripts/discourse/initializers/decrypt-topics.js
@@ -118,6 +118,10 @@ export default {
     const self = this;
     Component.reopen({
       didRender() {
+        const topic = self.container.lookup("controller:topic").model;
+        if (topic?.encrypted_title) {
+          document.querySelector(".private_message").classList.add("encrypted");
+        }
         scheduleOnce("afterRender", self, () => {
           discourseDebounce(self, self.decryptTopicTitles, 500);
         });

--- a/assets/javascripts/discourse/initializers/decrypt-topics.js
+++ b/assets/javascripts/discourse/initializers/decrypt-topics.js
@@ -118,10 +118,6 @@ export default {
     const self = this;
     Component.reopen({
       didRender() {
-        const topic = self.container.lookup("controller:topic").model;
-        if (topic?.encrypted_title) {
-          document.querySelector(".private_message").classList.add("encrypted");
-        }
         scheduleOnce("afterRender", self, () => {
           discourseDebounce(self, self.decryptTopicTitles, 500);
         });
@@ -243,7 +239,12 @@ export default {
     }
 
     const topicController = this.container.lookup("controller:topic");
-    const topicId = topicController.get("model.id");
+    const topic = topicController.get("model");
+    const topicId = topic.id;
+
+    if (topic?.encrypted_title) {
+      document.querySelector(".private_message").classList.add("encrypted");
+    }
 
     getTopicTitle(topicId).then((topicTitle) => {
       // Update fancy title stored in model

--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -182,3 +182,7 @@ pre.exported-key-pair {
     }
   }
 }
+
+.private_message.encrypted .move-to-topic {
+  display: none;
+}

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -865,6 +865,7 @@ acceptance("Encrypt", function (needs) {
       document.title,
       "Top Secret Title - QUnit Discourse Tests"
     );
+    assert.ok(exists(".private_message.encrypted"), "encrypted class is added");
   });
 
   test("encrypt settings visible only if user can encrypt", async (assert) => {


### PR DESCRIPTION
Moving encrypted posts button should be disabled as this feature is not yet supported.