### PR TITLE
FIX: Ensure encrypted file name is updated

### DIFF
--- a/assets/javascripts/lib/uppy-upload-encrypt-plugin.js
+++ b/assets/javascripts/lib/uppy-upload-encrypt-plugin.js
@@ -56,6 +56,10 @@ export default class UppyUploadEncrypt extends UploadPreProcessorPlugin {
       name: `${file.name}.encrypted`,
     });
 
+    this._setFileMeta(fileId, {
+      name: `${file.name}.encrypted`,
+    });
+
     this.storeEncryptedUpload(file.name, {
       key: exportedKey,
       metadata,


### PR DESCRIPTION
The "name" field is present in both the state and metadata of the files,
but was updated only in the state file. This was an issue because the
server thought it was a regular image and tried to process and failed
because it was in fact an encrypted file.