### PR TITLE
DEV: Fix an RSpec warning

### DIFF
--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -19,7 +19,7 @@ describe ::DiscourseEncrypt do
   it 'can enable encrypt if safe CSP' do
     SiteSetting.encrypt_enabled = false # plugin is enabled by default
     SiteSetting.content_security_policy_script_src = "default-src 'self' cdn.example.com|script-src 'self' js.example.com|style-src 'self' css.example.com"
-    expect { SiteSetting.encrypt_enabled = true }.not_to raise_error(Discourse::InvalidParameters)
+    expect { SiteSetting.encrypt_enabled = true }.not_to raise_error
   end
 
   it 'cannot enable encrypt if unsafe CSP' do


### PR DESCRIPTION
```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
```