### PR TITLE
FIX: Do not error when there is no `currentRouteName`

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-topics.js
+++ b/assets/javascripts/discourse/initializers/decrypt-topics.js
@@ -227,7 +227,7 @@ export default {
   },
 
   decryptTopicPage(data) {
-    if (!data.currentRouteName.startsWith("topic.")) {
+    if (!data.currentRouteName?.startsWith("topic.")) {
       return;
     }
 


### PR DESCRIPTION
The ember router doesn't guarantee a `currentRouteName` will be available at all times. This was causing failures in some other plugin's tests when discourse-encrypt was loaded at the same time