### PR TITLE
FIX: Check cached objects exist before accessing

### DIFF
--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -1158,6 +1158,39 @@ acceptance("Encrypt - active", function (needs) {
     );
   });
 
+  test("searching works when user has no encrypted topics", async function (assert) {
+    pretender.get("/search", (request) => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        {
+          posts: [],
+          topics: [],
+          grouped_search_result: {
+            term: request.queryParams.q,
+            type_filter: "private_messages",
+            post_ids: [],
+          },
+        },
+      ];
+    });
+
+    pretender.get("/encrypt/posts", () => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        {
+          success: "OK",
+          topics: [],
+          posts: [],
+        },
+      ];
+    });
+
+    await visit("/search?q=nothing+in:personal");
+    assert.strictEqual(count(".fps-result"), 0);
+  });
+
   test("searching in bookmarks", async function (assert) {
     const identity = await getIdentity();
 


### PR DESCRIPTION
This commit fixes multiple similar bugs in the search cache management
code where it tried to access object that did not exist, such as keys or
encrypted titles of topics that were not encrypted, maps of encrypted
topics (it does not exist for users with no encrypted topics), etc.