### PR TITLE
FIX: Hide convert to public topic button

### DIFF
--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -184,6 +184,9 @@ pre.exported-key-pair {
   }
 }
 
-.private_message.encrypted .move-to-topic {
-  display: none;
+.private_message.encrypted {
+  .move-to-topic,
+  .topic-admin-convert {
+    display: none;
+  }
 }


### PR DESCRIPTION
At this moment, it is impossible to convert a private encrypted topic
into a regular or public one. The other impossible action is moving
posts from encrypted topics. This commit ensures both buttons are hidden
(the "move posts" button was already hidden).