### PR TITLE
FIX: Hide quick-edit button for encrypted topics

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-topics.js
+++ b/assets/javascripts/discourse/initializers/decrypt-topics.js
@@ -56,12 +56,6 @@ function decryptTopicTitles(
         }
       })
       .catch(() => {});
-
-    // HACK: Hide quick-edit button for the time being
-    const quickEditBtn = element.querySelector(".edit-topic");
-    if (quickEditBtn) {
-      quickEditBtn.style.display = "none";
-    }
   });
 }
 

--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -185,6 +185,7 @@ pre.exported-key-pair {
 }
 
 .private_message.encrypted {
+  h1[data-topic-id] .edit-topic,
   .move-to-topic,
   .topic-admin-convert {
     display: none;

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -924,6 +924,10 @@ acceptance("Encrypt - active", function (needs) {
       "Top Secret Title - QUnit Discourse Tests"
     );
     assert.ok(exists(".private_message.encrypted"), "encrypted class is added");
+    assert.ok(
+      exists(".private_message.encrypted h1[data-topic-id] .edit-topic"),
+      "edit-topic is nested under correct DOM elements"
+    );
   });
 
   test("topic titles in notification panel are decrypted", async function (assert) {


### PR DESCRIPTION
This functionality has not been implemented yet and using it can result
in broken topic titles.