### PR TITLE
FIX: Add only valid search results

### DIFF
--- a/assets/javascripts/discourse/initializers/add-search-results.js
+++ b/assets/javascripts/discourse/initializers/add-search-results.js
@@ -78,7 +78,7 @@ function addEncryptedSearchResultsFromCache(cache, results) {
   const existentTopicIds = new Set(results.topics.map((topic) => topic.id));
   const topics = {};
   Object.values(cache.topics || {}).forEach((topic) => {
-    if (existentTopicIds.has(topic.id)) {
+    if (existentTopicIds.has(topic.id) || !topic.title) {
       return;
     }
 


### PR DESCRIPTION
In production, we have noticed that not all cached items are valid. It
is uncertain if this happens because of a bug in the cache functions,
malformed encrypted content or an issue during decryption.

This commit adds a sanity check to ensure only valid cached topic are
searched.