### PR TITLE
FIX: Use object methods to set properties of Draft

### DIFF
--- a/assets/javascripts/discourse/initializers/encrypt-drafts.js
+++ b/assets/javascripts/discourse/initializers/encrypt-drafts.js
@@ -124,9 +124,14 @@ export default {
           return this._super(site).then(() => {
             this.content.forEach((draft) => {
               if (draft.data.encrypted) {
-                draft.title = ":lock: " + I18n.t("encrypt.encrypted_title");
-                draft.title = emojiUnescape(escapeExpression(draft.title));
-                draft.excerpt = I18n.t("encrypt.encrypted_post");
+                draft.setProperties({
+                  title: emojiUnescape(
+                    escapeExpression(
+                      ":lock: " + I18n.t("encrypt.encrypted_title")
+                    )
+                  ),
+                  excerpt: I18n.t("encrypt.encrypted_post"),
+                });
               }
             });
           });


### PR DESCRIPTION
Draft is an Ember Object and this is why 'set' and 'setProperties' must
be used to update the value of its properties.