### PR TITLE
DEV: Only add timer counter on PMs

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -504,7 +504,8 @@ export default {
 
       api.decorateWidget("post-meta-data:after", (dec) => {
         const post = dec.getModel();
-        if (post && post?.encrypted_raw !== "") {
+
+        if (post?.topic.archetype === "private_message") {
           return dec.attach("encrypted-post-timer-counter", { post });
         }
       });

--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -504,7 +504,9 @@ export default {
 
       api.decorateWidget("post-meta-data:after", (dec) => {
         const post = dec.getModel();
-        return dec.attach("encrypted-post-timer-counter", { post });
+        if (post && post?.encrypted_raw !== "") {
+          return dec.attach("encrypted-post-timer-counter", { post });
+        }
       });
     });
   },

--- a/assets/javascripts/discourse/widgets/encrypted-post-timer-counter.js
+++ b/assets/javascripts/discourse/widgets/encrypted-post-timer-counter.js
@@ -15,7 +15,7 @@ createWidget("encrypted-post-timer-counter", {
     }
   },
 
-  formatedClock(attrs) {
+  formattedClock(attrs) {
     const miliseconds = Math.max(
       moment(attrs.post.delete_at) - moment().utc(),
       60000
@@ -31,11 +31,11 @@ createWidget("encrypted-post-timer-counter", {
         {
           attributes: {
             title: i18n.t("encrypt.time_bomb.title", {
-              after: this.formatedClock(attrs),
+              after: this.formattedClock(attrs),
             }),
           },
         },
-        [iconNode("discourse-trash-clock"), this.formatedClock(attrs)]
+        [iconNode("discourse-trash-clock"), this.formattedClock(attrs)]
       );
     }
   },


### PR DESCRIPTION
This means we don't do extra work on regular posts and also fixes a broken display Organisms/Post in the styleguide when the encrypt plugin is present.

The PR also fixes a typo in the function name for `formatedClock`.