### PR TITLE
FIX: update deleted topic

### DIFF
--- a/lib/topics_controller_extensions.rb
+++ b/lib/topics_controller_extensions.rb
@@ -12,7 +12,7 @@ module DiscourseEncrypt::TopicsControllerExtensions
   def update
     @topic ||= Topic.find_by(id: params[:topic_id])
 
-    if @topic.is_encrypted? && encrypted_title = params[:encrypted_title].presence
+    if @topic&.is_encrypted? && params[:encrypted_title].presence
       guardian.ensure_can_edit!(@topic)
       @topic.encrypted_topics_data.update!(title: params.delete(:encrypted_title))
     end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -21,6 +21,12 @@ describe TopicsController do
       expect(response.status).to eq(200)
       expect(topic.reload.encrypted_topics_data.title).to eq('new encrypted title')
     end
+
+    it 'returns invalid access for deleted topic' do
+      topic.destroy!
+      put "/t/#{topic.slug}/#{topic.id}.json", params: { encrypted_title: 'new encrypted title' }
+      expect(response.status).to eq(403)
+    end
   end
 
   it 'not invited admin does not have access' do


### PR DESCRIPTION
When deleted topic is updated, 403 invalid access status should be returned instead of 500.