### PR TITLE
FEATURE: allow tagging & quick edit in encrypted PMs.

### DIFF
--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -185,7 +185,6 @@ pre.exported-key-pair {
 }
 
 .private_message.encrypted {
-  h1[data-topic-id] .edit-topic,
   .move-to-topic,
   .topic-admin-convert {
     display: none;

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -737,10 +737,7 @@ acceptance("Encrypt - active", function (needs) {
 
     await click(".private_message.encrypted h1[data-topic-id] .edit-topic");
 
-    assert.strictEqual(
-      query("#edit-title").value.trim(),
-      "Top Secret Title"
-    );
+    assert.strictEqual(query("#edit-title").value.trim(), "Top Secret Title");
   });
 
   test("topic titles in notification panel are decrypted", async function (assert) {

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -734,9 +734,12 @@ acceptance("Encrypt - active", function (needs) {
       "Top Secret Title - QUnit Discourse Tests"
     );
     assert.ok(exists(".private_message.encrypted"), "encrypted class is added");
-    assert.ok(
-      exists(".private_message.encrypted h1[data-topic-id] .edit-topic"),
-      "edit-topic is nested under correct DOM elements"
+
+    await click(".private_message.encrypted h1[data-topic-id] .edit-topic");
+
+    assert.strictEqual(
+      query("#edit-title").value.trim(),
+      "Top Secret Title"
     );
   });
 


### PR DESCRIPTION
This feature allows users to edit title and tags in the topic page's quick edit method.