### PR TITLE
DEV: Fix JS tests to use default site settings

### DIFF
--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -561,6 +561,9 @@ acceptance("Encrypt - active", function (needs) {
 
     await visit("/");
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
 
     requests = [];
     await fillIn("#reply-title", `Some hidden message ${PLAINTEXT}`);
@@ -652,6 +655,9 @@ acceptance("Encrypt - active", function (needs) {
 
     await visit("/");
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
     await fillIn("#reply-title", PLAINTEXT_TITLE);
     await fillIn(".d-editor-input", PLAINTEXT_RAW);
 


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413 which changes JS to load default yml site settings, the main one needing changes is that now the
allow_uncategorized_topics setting is false
by default, which requires setting the category
in the composer before using it.