### PR TITLE
FEATURE: new user option to configure if PMs are default encrypted.

### DIFF
--- a/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.hbs
+++ b/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.hbs
@@ -16,24 +16,36 @@
           {{#if isEncryptEnabled}}
             {{#if isEncryptActive}}
               <p>{{i18n "encrypt.preferences.status_enabled"}}</p>
-              {{d-button
-                icon="times"
-                action=(action "deactivateEncrypt")
-                label="encrypt.preferences.deactivate"
-                id="deactivate"
+              <fieldset class="control-group">
+                {{d-button
+                  icon="times"
+                  action=(action "deactivateEncrypt")
+                  label="encrypt.preferences.deactivate"
+                  id="deactivate"
+                }}
+                {{d-button
+                  icon="plus"
+                  action=(action "generatePaperKey" true)
+                  label="encrypt.generate_paper_key.title_device"
+                }}
+                {{d-button
+                  icon="ticket-alt"
+                  action=(action "generatePaperKey")
+                  label="encrypt.generate_paper_key.title"
+                }}
+                {{encrypt-preferences-dropdown
+                  onChange=(action "selectEncryptPreferencesDropdownAction")
+                }}
+              </fieldset>
+              {{preference-checkbox
+                labelKey="encrypt.preferences.encrypt_pms_default"
+                checked=model.user_option.encrypt_pms_default
               }}
-              {{d-button
-                icon="plus"
-                action=(action "generatePaperKey" true)
-                label="encrypt.generate_paper_key.title_device"
-              }}
-              {{d-button
-                icon="ticket-alt"
-                action=(action "generatePaperKey")
-                label="encrypt.generate_paper_key.title"
-              }}
-              {{encrypt-preferences-dropdown
-                onChange=(action "selectEncryptPreferencesDropdownAction")
+              {{save-controls
+                id="encrypt_preference_save"
+                model=model
+                action=(action "save")
+                saved=saved
               }}
             {{else}}
               <form>

--- a/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.js
+++ b/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.js
@@ -1,4 +1,4 @@
-import { computed, defineProperty } from "@ember/object";
+import { computed, defineProperty, action } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
 import {
   deleteDb,
@@ -18,7 +18,6 @@ import {
 import { importIdentity } from "discourse/plugins/discourse-encrypt/lib/protocol";
 import I18n from "I18n";
 import { getOwner } from "discourse-common/lib/get-owner";
-import { action } from "@ember/object";
 import { isTesting } from "discourse-common/config/environment";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
@@ -107,9 +106,7 @@ export default {
       .then(() => {
         this.appEvents.trigger("encrypt:status-changed");
       })
-      .catch(() =>
-        dialog.alert(I18n.t("encrypt.preferences.key_pair_invalid"))
-      )
+      .catch(() => dialog.alert(I18n.t("encrypt.preferences.key_pair_invalid")))
       .finally(() => {
         this.setProperties({
           passphrase: "",
@@ -185,7 +182,6 @@ export default {
         }
       })
       .catch(popupAjaxError);
-
   },
 
   @action

--- a/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.js
+++ b/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.js
@@ -1,4 +1,4 @@
-import { computed, defineProperty, action } from "@ember/object";
+import { action, computed, defineProperty } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
 import {
   deleteDb,

--- a/assets/javascripts/discourse/initializers/encrypt-composer.js
+++ b/assets/javascripts/discourse/initializers/encrypt-composer.js
@@ -57,7 +57,7 @@ export default {
             // (serialization), this method is called and `isEncrypted` is
             // reset.
             if (!this.isEncryptedChanged) {
-              isEncrypted = currentUser.user_option.encrypt_pms_default;
+              isEncrypted = currentUser.encrypt_pms_default;
             }
           }
 
@@ -77,7 +77,7 @@ export default {
         checkEncryptRecipients() {
           if (!this.targetRecipients) {
             this.setProperties({
-              isEncrypted: currentUser.user_option.encrypt_pms_default,
+              isEncrypted: currentUser.encrypt_pms_default,
               isEncryptedChanged: true,
               showEncryptError: true,
               encryptErrorUser: false,

--- a/assets/javascripts/discourse/initializers/encrypt-composer.js
+++ b/assets/javascripts/discourse/initializers/encrypt-composer.js
@@ -57,7 +57,7 @@ export default {
             // (serialization), this method is called and `isEncrypted` is
             // reset.
             if (!this.isEncryptedChanged) {
-              isEncrypted = this.siteSettings.encrypt_pms_default;
+              isEncrypted = currentUser.user_option.encrypt_pms_default;
             }
           }
 
@@ -77,7 +77,7 @@ export default {
         checkEncryptRecipients() {
           if (!this.targetRecipients) {
             this.setProperties({
-              isEncrypted: this.siteSettings.encrypt_pms_default,
+              isEncrypted: currentUser.user_option.encrypt_pms_default,
               isEncryptedChanged: true,
               showEncryptError: true,
               encryptErrorUser: false,

--- a/assets/javascripts/discourse/initializers/encrypt-user-options.js
+++ b/assets/javascripts/discourse/initializers/encrypt-user-options.js
@@ -1,0 +1,16 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+const ENCRYPT_PMS_DEFAULT = "encrypt_pms_default";
+
+export default {
+  name: "encrypt-user-options",
+
+  initialize(container) {
+    withPluginApi("0.11.0", (api) => {
+      const siteSettings = container.lookup("service:site-settings");
+      if (siteSettings.encrypt_enabled) {
+        api.addSaveableUserOptionField(ENCRYPT_PMS_DEFAULT);
+      }
+    });
+  },
+};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -73,6 +73,8 @@ en:
         import: "Import Encryption Key Pair"
         use_paper_key: "Use Paper Key"
         generate_key: "Generate New Key Pair"
+        encrypt_pms_default: "Encrypt all new personal messages by default"
+        save: "Save Changes"
 
       generate_paper_key:
         title: "Generate Paper Key"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 plugins:
   encrypt_enabled:
     default: true
+    client: true
     refresh: true
     validator: "EncryptEnabledValidator"
   auto_enable_encrypt:
@@ -13,4 +14,4 @@ plugins:
     list_type: simple
   encrypt_pms_default:
     client: true
-    default: true
+    default: false

--- a/db/migrate/20221102045508_add_encrypt_pms_default_to_user_options.rb
+++ b/db/migrate/20221102045508_add_encrypt_pms_default_to_user_options.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 class AddEncryptPmsDefaultToUserOptions < ActiveRecord::Migration[6.1]
-  def change
-    add_column :user_options, :encrypt_pms_default, :boolean, default: default_value, null: false
+  def up
+    add_column :user_options, :encrypt_pms_default, :boolean, null: true
+
+    execute "UPDATE user_options SET encrypt_pms_default = #{default_value}"
+
+    change_column :user_options, :encrypt_pms_default, :boolean, null: false
+  end
+
+  def down
+    remove_column :user_options, :encrypt_pms_default
   end
 
   def default_value

--- a/db/migrate/20221102045508_add_encrypt_pms_default_to_user_options.rb
+++ b/db/migrate/20221102045508_add_encrypt_pms_default_to_user_options.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddEncryptPmsDefaultToUserOptions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_options, :encrypt_pms_default, :boolean, default: default_value, null: false
+  end
+
+  def default_value
+    setting_value = DB.query_single("SELECT value FROM site_settings WHERE name = 'encrypt_pms_default'").first
+    setting_value == "t"
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -75,6 +75,8 @@ after_initialize do
     mount DiscourseEncrypt::Engine, at: '/'
   end
 
+  UserUpdater::OPTION_ATTR.push(:encrypt_pms_default)
+
   reloadable_patch do |plugin|
     Email::Sender.class_eval                 { prepend DiscourseEncrypt::EmailSenderExtensions }
     GroupedSearchResultSerializer.class_eval { prepend DiscourseEncrypt::GroupedSearchResultSerializerExtension }
@@ -317,6 +319,14 @@ after_initialize do
 
   add_to_serializer(:user, :include_can_encrypt?) do
     scope.can_encrypt?
+  end
+
+  add_to_serializer(:user_option, :encrypt_pms_default) do
+    object.encrypt_pms_default
+  end
+
+  add_model_callback(:user_option, :before_create) do
+    self.encrypt_pms_default = SiteSetting.encrypt_pms_default if SiteSetting.encrypt_enabled
   end
 
   #

--- a/plugin.rb
+++ b/plugin.rb
@@ -313,6 +313,14 @@ after_initialize do
     scope.can_encrypt?
   end
 
+  add_to_serializer(:current_user, :encrypt_pms_default, false) do
+    object.user_option.encrypt_pms_default
+  end
+
+  add_to_serializer(:current_user, :include_encrypt_pms_default?) do
+    scope.can_encrypt?
+  end
+
   add_to_serializer(:user, :can_encrypt, false) do
     true
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe User do
+  let(:user) { Fabricate(:user) }
+  
+  before do
+    SiteSetting.encrypt_enabled = true
+  end
+
+  describe 'user option #encrypt_pms_default' do
+    it 'disabled by default' do
+      expect(user.user_option.encrypt_pms_default).to eq(false)
+    end
+
+    it 'enabled if site setting value is true' do
+      SiteSetting.encrypt_pms_default = true
+      expect(user.user_option.encrypt_pms_default).to eq(true)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe User do
   let(:user) { Fabricate(:user) }
-  
+
   before do
     SiteSetting.encrypt_enabled = true
   end

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -41,7 +41,6 @@ import QUnit, { test } from "qunit";
 import { Promise } from "rsvp";
 import sinon from "sinon";
 import { cloneJSON } from "discourse-common/lib/object";
-import EmberObject from "@ember/object";
 
 /*
  * Checks if a string is not contained in a string.

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -160,7 +160,7 @@ function setupEncryptTests(needs) {
   needs.user({
     can_encrypt: true,
     user_option: EmberObject.create({
-      encrypt_pms_default: true
+      encrypt_pms_default: true,
     }),
   });
 

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -41,6 +41,7 @@ import QUnit, { test } from "qunit";
 import { Promise } from "rsvp";
 import sinon from "sinon";
 import { cloneJSON } from "discourse-common/lib/object";
+import EmberObject from "@ember/object";
 
 /*
  * Checks if a string is not contained in a string.
@@ -156,8 +157,12 @@ async function wait(statusOrWaiter, func) {
 }
 
 function setupEncryptTests(needs) {
-  needs.user({ can_encrypt: true });
-  needs.settings({ encrypt_pms_default: true });
+  needs.user({
+    can_encrypt: true,
+    user_option: EmberObject.create({
+      encrypt_pms_default: true
+    }),
+  });
 
   needs.hooks.beforeEach(function () {
     sinon.stub(EncryptLibDiscourse, "reload");

--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -159,9 +159,7 @@ async function wait(statusOrWaiter, func) {
 function setupEncryptTests(needs) {
   needs.user({
     can_encrypt: true,
-    user_option: EmberObject.create({
-      encrypt_pms_default: true,
-    }),
+    encrypt_pms_default: true,
   });
 
   needs.hooks.beforeEach(function () {


### PR DESCRIPTION
Previously, we only had site setting to control default encryption status of PMs. Now users can modify the setting in the user preferences page.