### PR TITLE
FIX: allow encrypt_pms_default to be null

### DIFF
--- a/db/post_migrate/20221123235603_allow_encrypt_pms_default_to_be_null.rb
+++ b/db/post_migrate/20221123235603_allow_encrypt_pms_default_to_be_null.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AllowEncryptPmsDefaultToBeNull < ActiveRecord::Migration[7.0]
+  def up
+    change_column_null(:user_options, :encrypt_pms_default, true)
+  end
+
+  def down
+    change_column_null(:user_options, :encrypt_pms_default, false)
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -314,7 +314,7 @@ after_initialize do
   end
 
   add_to_serializer(:current_user, :encrypt_pms_default, false) do
-    object.user_option.encrypt_pms_default
+    object.user_option.encrypt_pms_default || SiteSetting.encrypt_pms_default
   end
 
   add_to_serializer(:current_user, :include_encrypt_pms_default?) do
@@ -330,7 +330,7 @@ after_initialize do
   end
 
   add_to_serializer(:user_option, :encrypt_pms_default) do
-    object.encrypt_pms_default
+    object.encrypt_pms_default || SiteSetting.encrypt_pms_default
   end
 
   add_model_callback(:user_option, :before_create) do

--- a/spec/serializers/current_user_serialier_spec.rb
+++ b/spec/serializers/current_user_serialier_spec.rb
@@ -5,10 +5,19 @@ require 'rails_helper'
 describe CurrentUserSerializer do
   let(:user) { Fabricate(:user) }
 
-  it 'contains public and private key' do
+  it 'contains public, private key and encrypt_pms_default' do
     UserEncryptionKey.create!(user_id: user.id, encrypt_public: "public key", encrypt_private: "private key")
+    SiteSetting.encrypt_pms_default = true
     serialized = described_class.new(user, scope: Guardian.new(user), root: false).as_json
     expect(serialized[:encrypt_public]).to eq("public key")
     expect(serialized[:encrypt_private]).to eq("private key")
+    expect(serialized[:encrypt_pms_default]).to be true
+  end
+
+  it 'use SiteSetting as default when encrypt_pms_default is not set' do
+    user.user_option.update!(encrypt_pms_default: nil)
+    UserEncryptionKey.create!(user_id: user.id, encrypt_public: "public key", encrypt_private: "private key")
+    serialized = described_class.new(user, scope: Guardian.new(user), root: false).as_json
+    expect(serialized[:encrypt_pms_default]).to be false
   end
 end


### PR DESCRIPTION
We should allow `encrypt_pms_default` to be null in case plugin is disabled or deleted.

In addition, fallback is added to use value from SiteSetting.