### PR TITLE
FIX: Broken mention lookup

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -206,8 +206,8 @@ function postProcessPost(siteSettings, site, topicId, post) {
   const unseenMentions = linkSeenMentions(post, siteSettings);
   if (unseenMentions.length > 0) {
     if (!mentionsQueues[topicId]) {
-      mentionsQueues[topicId] = new DebouncedQueue(500, (items) =>
-        fetchUnseenMentions(items, topicId)
+      mentionsQueues[topicId] = new DebouncedQueue(500, (names) =>
+        fetchUnseenMentions({ names, topicId })
       );
     }
     mentionsQueues[topicId]

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -114,6 +114,15 @@ module EncryptSystemHelpers
       Rails.root.join("plugins", "discourse-encrypt", "spec/fixtures/test_public_key_#{num}.txt"),
     ).chomp
   end
+
+  def enable_encrypt_for_user_in_session(user, user_preferences_page)
+    using_session("user_#{user.username}_enable_encrypt") do |session|
+      sign_in(user)
+      enable_encrypt_with_keys_for_user(user, 2)
+      activate_encrypt(user_preferences_page, user, 2)
+      session.quit
+    end
+  end
 end
 
 RSpec.configure { |config| config.include EncryptSystemHelpers, type: :system }

--- a/spec/system/decrypt_encrypted_topic_posts_spec.rb
+++ b/spec/system/decrypt_encrypted_topic_posts_spec.rb
@@ -4,6 +4,7 @@ describe "Encrypt | Decypting topic posts", type: :system, js: true do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:topic_title) { "This is a new topic for encryption" }
 
   before do
@@ -13,35 +14,32 @@ describe "Encrypt | Decypting topic posts", type: :system, js: true do
     activate_encrypt(user_preferences_page, current_user)
   end
 
+  def select_other_user_for_pm
+    find("#private-message-users").click
+    find("#private-message-users-filter input[name='filter-input-search']").send_keys(
+      other_user.username,
+    )
+    find(".email-group-user-chooser-row").click
+  end
+
   describe "with hashtags" do
     fab!(:category) { Fabricate(:category, name: "TODO", slug: "todo") }
     fab!(:tag) { Fabricate(:tag, name: "bugs") }
-    fab!(:other_user) { Fabricate(:user, username: "otherguy") }
-    let!(:topic_page) { PageObjects::Pages::Topic.new }
+    fab!(:other_user) { Fabricate(:user) }
 
     before { SiteSetting.enable_experimental_hashtag_autocomplete = true }
 
     it "decrypts the post" do
-      using_session("otherguy_encrypt") do
-        sign_in(other_user)
-        enable_encrypt_with_keys_for_user(other_user, 2)
-        activate_encrypt(user_preferences_page, other_user, 2)
-      end
+      enable_encrypt_for_user_in_session(other_user, user_preferences_page)
 
-      visit "/new-message"
+      topic_page.open_new_message
       expect(page).to have_css(".encrypt-controls .d-icon-lock")
 
-      # select other user to send the message to (who has encryption enabled)
-      find("#private-message-users").click
-      find("#private-message-users-filter input[name='filter-input-search']").send_keys("otherguy")
-      find(".email-group-user-chooser-row").click
+      select_other_user_for_pm
 
-      # fill topic details in composer + create
-      find("#reply-title").fill_in(with: topic_title)
-      find("#reply-control .d-editor-input").fill_in(
-        with: "Here are some hashtags for decryption later on #todo #bugs",
-      )
-      find("#reply-control .save-or-cancel .create").click
+      topic_page.fill_in_composer_title(topic_title)
+      topic_page.fill_in_composer("Here are some hashtags for decryption later on #todo #bugs")
+      topic_page.send_reply
 
       # encryption loading and processing takes a little longer than usual
       using_wait_time(5) do
@@ -53,6 +51,38 @@ describe "Encrypt | Decypting topic posts", type: :system, js: true do
       # make sure hashtags are rendered by the post decrypter
       expect(page).to have_css(".hashtag-cooked[data-slug='todo']")
       expect(page).to have_css(".hashtag-cooked[data-slug='bugs']")
+    end
+  end
+
+  describe "with mentions" do
+    fab!(:user_2) { Fabricate(:user) }
+    fab!(:user_3) { Fabricate(:user) }
+    fab!(:other_user) { Fabricate(:user) }
+
+    it "decrypts the post" do
+      enable_encrypt_for_user_in_session(other_user, user_preferences_page)
+
+      topic_page.open_new_message
+      expect(page).to have_css(".encrypt-controls .d-icon-lock")
+
+      select_other_user_for_pm
+
+      topic_page.fill_in_composer_title(topic_title)
+      topic_page.fill_in_composer(
+        "Here are some mentions for decryption later on @#{user_2.username} @#{user_3.username}",
+      )
+      topic_page.send_reply
+
+      # encryption loading and processing takes a little longer than usual
+      using_wait_time(5) do
+        expect(find(".fancy-title")).to have_content(topic_title)
+        expect(page).to have_css(".d-icon-user-secret.private-message-glyph")
+        expect(page).to have_content("Here are some mentions for decryption later")
+      end
+
+      # make sure mentions are rendered by the post decrypter
+      expect(page).to have_css(".mention[href='/u/#{user_2.username}']")
+      expect(page).to have_css(".mention[href='/u/#{user_3.username}']")
     end
   end
 end


### PR DESCRIPTION
Since the core commit https://github.com/discourse/discourse/commit/93859037ef776b83b9840e528a739050c600922c lookups
for mentions in encrypted posts has been broken. This commit fixes
the issue, using the new fetchUnseenMentions method signature and
adding a system spec to cover this case.
