### PR TITLE
FIX: "Copy to clipboard" string was only visible to admins

### DIFF
--- a/assets/javascripts/discourse/templates/modal/export-key-pair.hbs
+++ b/assets/javascripts/discourse/templates/modal/export-key-pair.hbs
@@ -11,8 +11,8 @@
     icon="far-clipboard"
     label=(if
       copied
-      "admin.customize.copied_to_clipboard"
-      "admin.customize.copy_to_clipboard"
+      "encrypt.export.copied_to_clipboard"
+      "encrypt.export.copy_to_clipboard"
     )
     disabled=inProgress
     action=(action "copy")

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -93,6 +93,8 @@ en:
       export:
         title: "Export Encryption Key Pair"
         instructions: "Exporting your key pair is another backup mechanism. Please note that the exported key pair is unprotected and it can decrypt all your private conversations."
+        copy_to_clipboard: "Copy to Clipboard"
+        copied_to_clipboard: "Copied to Clipboard"
 
       rotate:
         title: "Rotate Encryption Key Pair"


### PR DESCRIPTION
Reusing a translation from core within a plugin is a bad idea and `admin.*` strings are only visible to admins.