### PR TITLE
DEV: Resolve `save` `computed-property.override` deprecation

### DIFF
--- a/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.hbs
+++ b/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.hbs
@@ -49,7 +49,7 @@
               <SaveControls
                 @id="encrypt_preference_save"
                 @model={{model}}
-                @action={{action "save"}}
+                @action={{action "savePreference"}}
                 @saved={{saved}}
               />
             {{else}}

--- a/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.js
+++ b/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.js
@@ -171,7 +171,7 @@ export default {
   },
 
   @action
-  save() {
+  savePreference() {
     this.set("saved", false);
     return this.model
       .save(["encrypt_pms_default"])


### PR DESCRIPTION
To resolve
```
DEPRECATION: The <discourse@component:plugin-connector::ember19469>#save computed property was just overridden. This removes the computed property and replaces it with a plain value, and has been deprecated
```
we need to not use the saved namespace of `save` as it was overriding a already defined computed function printing the deprecation above. Instead use a more unique `savePreference` action name.