### PR TITLE
FIX: Don't error when rotating identities of protocol-v0

### DIFF
--- a/assets/javascripts/discourse/components/modal/rotate-key-pair.js
+++ b/assets/javascripts/discourse/components/modal/rotate-key-pair.js
@@ -45,16 +45,21 @@ export default class RotateKeyPair extends Component {
       ]);
       this.loadingState = "rotating";
 
-      // Rotating signatures will invalidate all previous signatures.
-      newIdentity.signPublic = oldIdentity.signPublic;
-      newIdentity.signPrivate = oldIdentity.signPrivate;
+      // Don't rotate signatures because that will invalidate all previous
+      // signatures.
+      // When the old identity is v0, there's no keypair for signing, so don't
+      // overwrite the new identity's signing keypair with nothing (undefined)
+      if (oldIdentity.signPublic && oldIdentity.signPrivate) {
+        newIdentity.signPublic = oldIdentity.signPublic;
+        newIdentity.signPrivate = oldIdentity.signPrivate;
+      }
 
       const topicKeys = {};
       // eslint-disable-next-line no-restricted-globals
       await Promise.all(
         Object.entries(data.topic_keys).map(async ([topicId, topicKey]) => {
           const key = await importKey(topicKey, oldIdentity.encryptPrivate);
-          topicKeys[topicId] = exportKey(key, newIdentity.encryptPublic);
+          topicKeys[topicId] = await exportKey(key, newIdentity.encryptPublic);
         })
       );
 

--- a/assets/javascripts/lib/protocol.js
+++ b/assets/javascripts/lib/protocol.js
@@ -43,7 +43,9 @@ export const ENCRYPT_PROTOCOL_VERSION = 1;
  * @return {Promise}
  */
 export function generateIdentity(version) {
-  version = version || ENCRYPT_PROTOCOL_VERSION;
+  if (version === undefined) {
+    version = ENCRYPT_PROTOCOL_VERSION;
+  }
 
   let promise = Promise.reject();
   if (version === 0) {

--- a/assets/javascripts/lib/protocol.js
+++ b/assets/javascripts/lib/protocol.js
@@ -43,9 +43,7 @@ export const ENCRYPT_PROTOCOL_VERSION = 1;
  * @return {Promise}
  */
 export function generateIdentity(version) {
-  if (version === undefined) {
-    version = ENCRYPT_PROTOCOL_VERSION;
-  }
+  version ??= ENCRYPT_PROTOCOL_VERSION;
 
   let promise = Promise.reject();
   if (version === 0) {


### PR DESCRIPTION
Users who are currently stuck with v0 identities are unable to rotate their identities into v1 because of a bug where the old identity is assumed to be v1 and has signing keys, but v0 identities don't have signing keys. When rotating an identity, the signing keys of the old identity are copied to the new identity to keep old signatures working. However, when the old identity is v0 (which has no signing keys), we attempt to copy the old signature keys (`undefined`) to the new v1 identity, but it ends up with no signing keys and fails to be saved because v1 identities are expected to have signing keys.

This PR fixes the issue by checking for the existence of old signing keys before copying them to the new identity. If there are no signing keys in the old identity, we let the new identity save with the signing keys that are generated with it.