### PR TITLE
DEV: Avoid rendering label when there is nothing to render

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-action-after/encrypt.hbs
+++ b/assets/javascripts/discourse/connectors/composer-action-after/encrypt.hbs
@@ -20,14 +20,17 @@
             @topicDeleteAt={{this.model.topic.delete_at}}
             @onChange={{action "timerClicked"}}
           />
-          <span
-            title={{i18n
-              "encrypt.time_bomb.title"
-              after=this.model.deleteAfterMinutesLabel
-            }}
-          >
-            {{this.model.deleteAfterMinutesLabel}}
-          </span>
+
+          {{#if this.model.deleteAfterMinutesLabel}}
+            <span
+              title={{i18n
+                "encrypt.time_bomb.title"
+                after=this.model.deleteAfterMinutesLabel
+              }}
+            >
+              {{this.model.deleteAfterMinutesLabel}}
+            </span>
+          {{/if}}
         {{/unless}}
       {{/if}}
 


### PR DESCRIPTION
Why this change? 

`this.model.deleteAfterMinutesLabel` can be set to `null` and when it is `null`, we were rendering a span with a broken translation and no text. This was caught after we started raising an error when a `I18n.translate` is used but is missing an interpolation argument: https://github.com/discourse/discourse/pull/23527