### PR TITLE
FIX: Decrypt posts correctly under Ember 5.x

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -468,7 +468,7 @@ export default {
 
           const cooked = await cookAsync(plaintext.raw);
           state.encryptState = "decrypted";
-          state.plaintext = cooked.string;
+          state.plaintext = cooked.toString();
           this.scheduleRerender();
         } catch (error) {
           const store = getOwner(this).lookup("service:encrypt-widget-store");


### PR DESCRIPTION
`cooked` was an Ember SafeString. The internal storage of the string changed from `.string` to `.__string` at some point between Ember 3.28 and Ember 5. Instead, we can use `toString()` which is guaranteed to work in all situations