### PR TITLE
DEV: Stop importing from `pretty-text/engines`

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -32,7 +32,6 @@ import {
 } from "discourse/plugins/discourse-encrypt/lib/protocol";
 import { downloadEncryptedFile } from "discourse/plugins/discourse-encrypt/lib/uploads";
 import I18n from "I18n";
-import { ATTACHMENT_CSS_CLASS } from "pretty-text/engines/discourse-markdown-it";
 import {
   MISSING,
   lookupCachedUploadUrl,
@@ -143,7 +142,7 @@ function resolveShortUrlElement($el) {
     $el.attr("href", url);
 
     const isEncrypted = $el.data("key") || $el.text().endsWith(".encrypted");
-    if (!isEncrypted || !$el.hasClass(ATTACHMENT_CSS_CLASS)) {
+    if (!isEncrypted || !$el.hasClass("attachment")) {
       return;
     }
 


### PR DESCRIPTION
Modules under pretty-text/engines are asynchronously loaded. Importing them directly from a plugin is risky because there's no guarantee they'll actually be available at the time of import.

In this case, we were only importing a simple string constant, and there's very little risk of it changing. Much safer to just hard-code it.

This change was motivated by https://github.com/discourse/discourse/pull/23859, which significantly refactors the asynchronously-loaded code into more modern patterns.