### PR TITLE
DEV: Avoid signature mismatch error in tests

### DIFF
--- a/test/javascripts/acceptance/encrypt-test.js
+++ b/test/javascripts/acceptance/encrypt-test.js
@@ -234,7 +234,7 @@ async function setupEncryptedTopicPretender(
             {
               id: 42,
               name: null,
-              username: "bar",
+              username: "eviltrout",
               avatar_template:
                 "/letter_avatar_proxy/v4/letter/b/000000/{size}.png",
               created_at: "2020-01-01T12:00:00.000Z",


### PR DESCRIPTION
The content is signed with the name 'eviltrout', so let's update the fixture to match