### PR TITLE
DEV: Replace deprecated min_trust_to_edit_post

### DIFF
--- a/spec/requests/encrypt_controller_spec.rb
+++ b/spec/requests/encrypt_controller_spec.rb
@@ -120,7 +120,7 @@ describe DiscourseEncrypt::EncryptController do
   describe "#update_post" do
     let!(:post) { Fabricate(:encrypt_post) }
 
-    before { SiteSetting.min_trust_to_edit_post = 2 }
+    before { SiteSetting.edit_post_allowed_groups = 12 }
 
     it "is not raising error when user cannot edit because min trust level" do
       sign_in(post.user)


### PR DESCRIPTION
### What is this change?

In https://github.com/discourse/discourse/pull/24840, `min_trust_to_edit_posts` site setting was replaced by `edit_post_allowed_groups`. This PR replaces the former, deprecated one, with the latter.