### PR TITLE
DEV: Remove the use of `Capybara::Session#quit`

### DIFF
--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -116,11 +116,10 @@ module EncryptSystemHelpers
   end
 
   def enable_encrypt_for_user_in_session(user, user_preferences_page)
-    using_session("user_#{user.username}_enable_encrypt") do |session|
+    using_session("user_#{user.username}_enable_encrypt") do
       sign_in(user)
       enable_encrypt_with_keys_for_user(user, 2)
       activate_encrypt(user_preferences_page, user, 2)
-      session.quit
     end
   end
 end


### PR DESCRIPTION
See https://github.com/discourse/discourse/commit/68a3f7783e76064feb19cf86de53f3f4367e80d1