### PR TITLE
Revert "DEV: Explicitly register problem check"

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -112,8 +112,6 @@ after_initialize do
     UserNotificationRenderer.singleton_class.prepend DiscourseEncrypt::UserNotificationRendererExtensions
   end
 
-  register_problem_check ProblemCheck::UnsafeCsp
-
   register_search_topic_eager_load do |opts|
     if SiteSetting.encrypt_enabled? && opts[:search_pms]
       %i[encrypted_topics_users encrypted_topics_data]


### PR DESCRIPTION
Reverts discourse/discourse-encrypt#310

This commit is currently breaking Discourse Core CI. I am reverting for now.

```
1 gem installed
	64: from bin/rake:13:in `<main>'
	63: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:80:in `run'
	62: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:208:in `standard_exception_handling'
	61: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:83:in `block in run'
	60: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:132:in `top_level'
	59: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:147:in `run_with_threads'
	58: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:138:in `block in top_level'
	57: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:138:in `each'
	56: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:138:in `block (2 levels) in top_level'
	55: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:182:in `invoke_task'
	54: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:188:in `invoke'
	53: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `invoke_with_call_chain'
	52: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `synchronize'
	51: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:218:in `block in invoke_with_call_chain'
	50: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:241:in `invoke_prerequisites'
	49: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:241:in `each'
	48: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:243:in `block in invoke_prerequisites'
	47: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `invoke_with_call_chain'
	46: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `synchronize'
	45: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:218:in `block in invoke_with_call_chain'
	44: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:241:in `invoke_prerequisites'
	43: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:241:in `each'
	42: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:243:in `block in invoke_prerequisites'
	41: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `invoke_with_call_chain'
	40: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `synchronize'
	39: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
	38: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:281:in `execute'
	37: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:281:in `each'
	36: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:281:in `block in execute'
	35: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/application.rb:506:in `block in run_tasks_blocks'
	34: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/application.rb:348:in `require_environment!'
	33: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	32: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	31: from <internal:/usr/local/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	30: from <internal:/usr/local/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	29: from /__w/discourse/discourse/config/environment.rb:7:in `<main>'
	28: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/application.rb:372:in `initialize!'
	27: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/initializable.rb:60:in `run_initializers'
	26: from /usr/local/lib/ruby/3.2.0/tsort.rb:205:in `tsort_each'
	25: from /usr/local/lib/ruby/3.2.0/tsort.rb:226:in `tsort_each'
	24: from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `each_strongly_connected_component'
	23: from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `call'
	22: from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `each'
	21: from /usr/local/lib/ruby/3.2.0/tsort.rb:349:in `block in each_strongly_connected_component'
	20: from /usr/local/lib/ruby/3.2.0/tsort.rb:431:in `each_strongly_connected_component_from'
	19: from /usr/local/lib/ruby/3.2.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	18: from /usr/local/lib/ruby/3.2.0/tsort.rb:228:in `block in tsort_each'
	17: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/initializable.rb:61:in `block in run_initializers'
	16: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/initializable.rb:32:in `run'
	15: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/initializable.rb:32:in `instance_exec'
	14: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8.1/lib/rails/application/finisher.rb:87:in `block in <module:Finisher>'
	13: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8.1/lib/active_support/lazy_load_hooks.rb:75:in `run_load_hooks'
	12: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8.1/lib/active_support/lazy_load_hooks.rb:75:in `each'
	11: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8.1/lib/active_support/lazy_load_hooks.rb:76:in `block in run_load_hooks'
	10: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8.1/lib/active_support/lazy_load_hooks.rb:90:in `execute_hook'
	9: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8.1/lib/active_support/lazy_load_hooks.rb:85:in `with_execution_control'
	8: from /__w/discourse/discourse/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8.1/lib/active_support/lazy_load_hooks.rb:92:in `block in execute_hook'
	7: from /__w/discourse/discourse/config/application.rb:239:in `block in <class:Application>'
	6: from /__w/discourse/discourse/lib/plugin.rb:6:in `initialization_guard'
	5: from /__w/discourse/discourse/config/application.rb:239:in `block (2 levels) in <class:Application>'
	4: from /__w/discourse/discourse/config/application.rb:239:in `each'
	3: from /__w/discourse/discourse/lib/plugin/instance.rb:555:in `notify_after_initialize'
	2: from /__w/discourse/discourse/lib/plugin/instance.rb:555:in `each'
	1: from /__w/discourse/discourse/lib/plugin/instance.rb:557:in `block in notify_after_initialize'
/__w/discourse/discourse/plugins/discourse-encrypt/plugin.rb:115:in `block in activate!': undefined method `register_problem_check' for #<Plugin::Instance:0x00007f[177](https://github.com/discourse/discourse/actions/runs/8441296754/job/23411267205?pr=26373#step:22:178)0017a00 @metadata=#<Plugin::Metadata:0x00007f17742eb818 @name="discourse-encrypt", @about="Provides private, encrypted messaging between end-users.", @meta_topic_id=107918, @version="1.0", @authors="Dan Ungureanu", @url="https://github.com/discourse/discourse-encrypt">, @path="/__w/discourse/discourse/plugins/discourse-encrypt/plugin.rb", @idx=0, @enabled_site_setting=:encrypt_enabled, @assets=[["/__w/discourse/discourse/plugins/discourse-encrypt/assets/stylesheets/common/encrypt.scss", nil, "discourse-encrypt"], ["/__w/discourse/discourse/plugins/discourse-encrypt/assets/stylesheets/colors.scss", :color_definitions, "discourse-encrypt"]], @directory_name="discourse-encrypt", @initializers=[#<Proc:0x00007f177014d898 /__w/discourse/discourse/plugins/discourse-encrypt/plugin.rb:34>], @styles=[], @javascripts=[], @locales=[], @service_workers=[], @seed_data={}, @extra_js_file_path="/__w/discourse/discourse/app/assets/javascripts/plugins/discourse-encrypt_extra.js", @asset_filters=[], @color_schemes=[]> (NoMethodError)

** INCOMPATIBLE PLUGIN **

You are unable to start Discourse due to errors in the plugin at
/__w/discourse/discourse/plugins/discourse-encrypt
```