### PR TITLE
DEV: Remove `{{~! ~}}` whitespace workaround

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-action-after/encrypt.hbs
+++ b/assets/javascripts/discourse/connectors/composer-action-after/encrypt.hbs
@@ -14,9 +14,9 @@
 
       {{~#if model.isEncrypted}}
         {{~#unless model.editingPost~}}
-          <div class="composer-action-divider"></div>
-          {{~! ~}}
-          <EncryptedPostTimerDropdown
+          <div
+            class="composer-action-divider"
+          ></div>{{! inline to avoid whitespace}}<EncryptedPostTimerDropdown
             @topicDeleteAt={{this.model.topic.delete_at}}
             @onChange={{action "timerClicked"}}
           />


### PR DESCRIPTION
This was causing a warning on every build

> unexpectedly found "! ~" when slicing source, but expected " "

Not 100% sure of the root cause... but we can stop the noise by removing the `~` from the comments