### PR TITLE
UX: show a 🚫 on checklist items

### DIFF
--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -196,3 +196,11 @@ body.encrypted-topic-page {
     display: none;
   }
 }
+
+// Show a 🚫 on checklist items in encrypted posts/preview
+.encrypted-topic-page,
+.reply-area:has(.encrypt-toggle.enabled) {
+  span.chcklst-box {
+    cursor: not-allowed !important;
+  }
+}


### PR DESCRIPTION
This is a companion to https://github.com/discourse/discourse/pull/26752 and shows a 🚫 cursor when hovering over a checklist item in an encrypted post to (hopefully) better signal to the user that checking an item won't work in an encrypted post.