### PR TITLE
FIX: Remove unsafe-eval from `safe_csp_src?` check

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -36,7 +36,7 @@ after_initialize do
     PLUGIN_NAME = "discourse-encrypt"
 
     def self.safe_csp_src?(value)
-      !value.include?("'unsafe-inline'") && !value.include?("'unsafe-eval'")
+      !value.include?("'unsafe-inline'")
     end
   end
 


### PR DESCRIPTION
This check was introduced as a loose guard against admin-initiated-xss attacks on discourse-encrypt. The unsafe-eval directive isn't related to those kind of xss protections. Ultimately: if someone can control a trusted JS script, then they are trusted. unsafe-eval doesn't affect that.