### PR TITLE
DEV: Update hashtags import path

### DIFF
--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -12,7 +12,7 @@ import { ajax } from "discourse/lib/ajax";
 import {
   fetchUnseenHashtagsInContext,
   linkSeenHashtagsInContext,
-} from "discourse/lib/hashtag-autocomplete";
+} from "discourse/lib/hashtag-decorator";
 import lightbox from "discourse/lib/lightbox";
 import {
   fetchUnseenMentions,


### PR DESCRIPTION
fetchUnseenHashtagsInContext and linkSeenHashtagsInContext
are now in discourse/app/lib/hashtag-decorator since
https://github.com/discourse/discourse/commit/c7860173c1683fcbe33600d29b5294c0bb228253
