### PR TITLE
DEV: update spec to account that unsafe CSP is validated in core

### DIFF
--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -17,15 +17,8 @@ describe ::DiscourseEncrypt do
 
   it "can enable encrypt if safe CSP" do
     SiteSetting.encrypt_enabled = false # plugin is enabled by default
-    SiteSetting.content_security_policy_script_src =
-      "default-src 'self' cdn.example.com|script-src 'self' js.example.com|style-src 'self' css.example.com"
+    SiteSetting.content_security_policy_script_src = "'unsafe-eval'"
     expect { SiteSetting.encrypt_enabled = true }.not_to raise_error
-  end
-
-  it "cannot enable encrypt if unsafe CSP" do
-    SiteSetting.encrypt_enabled = false # plugin is enabled by default
-    SiteSetting.content_security_policy_script_src = "'unsafe-eval'|'unsafe-inline'"
-    expect { SiteSetting.encrypt_enabled = true }.to raise_error(Discourse::InvalidParameters)
   end
 
   it "cannot have unsafe CSP if encrypt is enabled" do


### PR DESCRIPTION
CSP validation is enabled in core from https://github.com/discourse/discourse/pull/27564, and therefore unsafe keywords/URLs are not allowed in test setup. Fixing the test first to unblock that PR, we may want to consider updating the logic here and adding a line to discourse-compat as a follow-up.