### PR TITLE
FIX: add_attachments signature

### DIFF
--- a/lib/email_sender_extensions.rb
+++ b/lib/email_sender_extensions.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module DiscourseEncrypt::EmailSenderExtensions
-  def add_attachments(post)
-    return if post.is_encrypted?
+  def add_attachments(*posts)
+    return if posts.any?(&:is_encrypted?)
     super
   end
 end


### PR DESCRIPTION
It has been changed in 96a0781bc181fdc4bda856bfb90b03ce55e342cf to support adding attachments from more than one post.

Internal ref - t/132149

Context - https://meta.discourse.org/t/e-mail-preview-summary-wrong-number-of-arguments-given-10-expected-1/312888