### PR TITLE
DEV: Add compatibility with OpenSSL 3

### DIFF
--- a/lib/user_extensions.rb
+++ b/lib/user_extensions.rb
@@ -19,7 +19,8 @@ module DiscourseEncrypt::UserExtensions
         n = OpenSSL::BN.new(Base64.urlsafe_decode64(jwk["n"]), 2)
         e = OpenSSL::BN.new(Base64.urlsafe_decode64(jwk["e"]), 2)
 
-        OpenSSL::PKey::RSA.new.tap { |k| k.set_key(n, e, nil) }
+        data_sequence = OpenSSL::ASN1.Sequence([OpenSSL::ASN1.Integer(n), OpenSSL::ASN1.Integer(e)])
+        OpenSSL::PKey::RSA.new(data_sequence.to_der)
       end
   end
 


### PR DESCRIPTION
From the `openssl` gem compatibility notes:

```
Deprecate the ability to modify OpenSSL::PKey::PKey instances. OpenSSL 3.0 made EVP_PKEY structure immutable, and hence the following methods are not available when Ruby/OpenSSL is linked against OpenSSL 3.0. [GitHub #480]

OpenSSL::PKey::RSA#set_key, #set_factors, #set_crt_params
OpenSSL::PKey::DSA#set_pqg, #set_key
OpenSSL::PKey::DH#set_pqg, #set_key, #generate_key!
OpenSSL::PKey::EC#private_key=, #public_key=, #group=, #generate_key!
```

Since we can no longer use `OpenSSL::PKey::RSA#set_key`, we have to use
another implementation which I abstracted from https://github.com/net-ssh/net-ssh/pull/875
