### PR TITLE
FIX: Add missing event handler

### DIFF
--- a/assets/javascripts/lib/database.js
+++ b/assets/javascripts/lib/database.js
@@ -246,6 +246,7 @@ export function deleteDb() {
         req.onsuccess = (evt) => resolve(evt);
         req.onerror = (evt) => resolve(evt);
         req.onblocked = (evt) => resolve(evt);
+        req.onupgradeneeded = (evt) => resolve(evt);
       });
     })
     .finally(() => {


### PR DESCRIPTION
IDBOpenDBRequest has one more possible event – `upgradeneeded`.

There's a change it's responsible for the flaky tests.