### PR TITLE
FEATURE: Allow users to decrypt existing PMs

### DIFF
--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -238,6 +238,54 @@ class DiscourseEncrypt::EncryptController < ApplicationController
     render json: success_json
   end
 
+  def data_for_decryption
+    raise Discourse::InvalidAccess if !SiteSetting.allow_decrypting_pms
+
+    topic = Topic.find(params[:topic_id])
+    guardian.ensure_can_see!(topic)
+    raise Discourse::NotFound if !topic.is_encrypted?
+
+    encrypted_data = topic.encrypted_topics_data
+
+    posts = topic.posts.where(post_type: Post.types[:regular], deleted_at: nil)
+
+    render json: { title: "#{encrypted_data.title}", posts: posts.map { |p| [p.id, p.raw] }.to_h }
+  end
+
+  def complete_decryption
+    raise Discourse::InvalidAccess if !SiteSetting.allow_decrypting_pms
+
+    topic = Topic.find(params[:topic_id])
+    guardian.ensure_can_see!(topic)
+    raise Discourse::NotFound if !topic.is_encrypted?
+
+    decrypted_title = params[:title]
+    decrypted_posts = params[:posts]
+
+    Topic.transaction do
+      decrypted_posts.each do |post_id, raw|
+        post = topic.posts.find(post_id)
+        raw += "\n\n---\n<small>(decrypted by `@#{current_user.username}`)</small>"
+
+        revision = { raw: raw }
+
+        revision[:title] = decrypted_title if post.post_number == 1
+
+        post.revise(
+          current_user,
+          **revision,
+          skip_validations: true,
+          bypass_rate_limiter: true,
+          bypass_bump: true,
+          edit_reason: "Decrypting topic",
+        )
+      end
+      topic.encrypted_topics_data.destroy!
+    end
+
+    render json: success_json
+  end
+
   private
 
   def ensure_can_encrypt

--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -265,7 +265,6 @@ class DiscourseEncrypt::EncryptController < ApplicationController
     Topic.transaction do
       decrypted_posts.each do |post_id, raw|
         post = topic.posts.find(post_id)
-        raw += "\n\n---\n<small>(decrypted by `@#{current_user.username}`)</small>"
 
         revision = { raw: raw }
 

--- a/assets/javascripts/discourse/components/modal/generate-paper-key.hbs
+++ b/assets/javascripts/discourse/components/modal/generate-paper-key.hbs
@@ -8,6 +8,7 @@
       "encrypt.generate_paper_key.title"
     )
   }}
+  class="generate-paper-key-modal"
 >
   <:body>
     <p>

--- a/assets/javascripts/discourse/connectors/topic-title/decrypt-topic-button.gjs
+++ b/assets/javascripts/discourse/connectors/topic-title/decrypt-topic-button.gjs
@@ -17,13 +17,6 @@ export default class DecryptTopicButton extends Component {
   @service currentUser;
   @service siteSettings;
 
-  @action
-  openDecryptModal() {
-    this.modal.show(DecryptTopicModal, {
-      model: { topic_id: this.args.outletArgs.model.id },
-    });
-  }
-
   get canDecrypt() {
     return (
       this.args.outletArgs.model.encrypted_title &&
@@ -31,6 +24,13 @@ export default class DecryptTopicButton extends Component {
       getEncryptionStatus(this.currentUser) !== ENCRYPT_DISABLED &&
       this.siteSettings.allow_decrypting_pms
     );
+  }
+
+  @action
+  openDecryptModal() {
+    this.modal.show(DecryptTopicModal, {
+      model: { topic_id: this.args.outletArgs.model.id },
+    });
   }
 
   <template>
@@ -46,8 +46,6 @@ export default class DecryptTopicButton extends Component {
 }
 
 class DecryptTopicModal extends Component {
-  @service router;
-
   @tracked running = false;
   @tracked done = false;
 

--- a/assets/javascripts/discourse/connectors/topic-title/decrypt-topic-button.gjs
+++ b/assets/javascripts/discourse/connectors/topic-title/decrypt-topic-button.gjs
@@ -1,0 +1,132 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import DModal from "discourse/components/d-modal";
+import i18n from "discourse-common/helpers/i18n";
+import {
+  ENCRYPT_DISABLED,
+  getEncryptionStatus,
+} from "discourse/plugins/discourse-encrypt/lib/discourse";
+import PermanentTopicDecrypter from "discourse/plugins/discourse-encrypt/lib/permanent-topic-decrypter";
+
+export default class DecryptTopicButton extends Component {
+  @service modal;
+  @service currentUser;
+  @service siteSettings;
+
+  @action
+  openDecryptModal() {
+    this.modal.show(DecryptTopicModal, {
+      model: { topic_id: this.args.outletArgs.model.id },
+    });
+  }
+
+  get canDecrypt() {
+    return (
+      this.args.outletArgs.model.encrypted_title &&
+      this.currentUser &&
+      getEncryptionStatus(this.currentUser) !== ENCRYPT_DISABLED &&
+      this.siteSettings.allow_decrypting_pms
+    );
+  }
+
+  <template>
+    {{#if this.canDecrypt}}
+      <DButton
+        @action={{this.openDecryptModal}}
+        @label="encrypt.decrypt_permanently.button"
+        @icon="unlock"
+        class="decrypt-topic-button"
+      />
+    {{/if}}
+  </template>
+}
+
+class DecryptTopicModal extends Component {
+  @service router;
+
+  @tracked running = false;
+  @tracked done = false;
+
+  @tracked logContent = "";
+
+  @action
+  async decryptTopic() {
+    this.running = true;
+
+    const decrypter = new PermanentTopicDecrypter(
+      this.args.model.topic_id,
+      this.log
+    );
+
+    try {
+      await decrypter.run();
+      this.log("Refresh page to continue");
+      this.done = true;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  @action
+  log(msg) {
+    this.logContent += msg + "\n";
+  }
+
+  @action
+  scrollBottom(element) {
+    element.scrollTop = element.scrollHeight;
+  }
+
+  @action
+  refresh() {
+    window.location.reload();
+  }
+
+  <template>
+    <DModal
+      @closeModal={{if this.done this.refresh @closeModal}}
+      @title={{i18n "encrypt.decrypt_permanently.modal_title"}}
+      class="decrypt-topic-modal"
+    >
+      <:body>
+        {{#if this.logContent}}
+          <pre
+            style="width: 100%; height: 200px; overflow-y: scroll;"
+            {{didUpdate this.scrollBottom this.logContent}}
+          >{{this.logContent}}</pre>
+        {{else}}
+          <p>{{i18n "encrypt.decrypt_permanently.modal_body"}}</p>
+        {{/if}}
+      </:body>
+      <:footer>
+        {{#if this.done}}
+          <DButton
+            @label="encrypt.decrypt_permanently.refresh_page"
+            class="btn-primary"
+            @action={{this.refresh}}
+          />
+        {{else}}
+          <DButton
+            @label="encrypt.decrypt_permanently.modal_cancel"
+            @action={{@closeModal}}
+            disabled={{this.running}}
+          />
+          <DButton
+            @label="encrypt.decrypt_permanently.modal_confirm"
+            class="btn-primary"
+            @action={{this.decryptTopic}}
+            disabled={{this.running}}
+            @isLoading={{this.running}}
+          />
+        {{/if}}
+      </:footer>
+    </DModal>
+  </template>
+}

--- a/assets/javascripts/lib/permanent-topic-decrypter.js
+++ b/assets/javascripts/lib/permanent-topic-decrypter.js
@@ -1,0 +1,144 @@
+import { lookupCachedUploadUrl } from "pretty-text/upload-short-url";
+import { ajax } from "discourse/lib/ajax";
+import { base64ToBuffer } from "discourse/plugins/discourse-encrypt/lib/base64";
+import { getTopicKey } from "discourse/plugins/discourse-encrypt/lib/discourse";
+import { decrypt } from "discourse/plugins/discourse-encrypt/lib/protocol";
+import { downloadEncryptedFile } from "discourse/plugins/discourse-encrypt/lib/uploads";
+
+const UPLOAD_REGEX = /\[(.+)\]\((upload:\/\/\w{27}.encrypted)\)/g;
+
+export default class PermanentTopicDecrypter {
+  topicId;
+  logCallback;
+
+  constructor(topicId, logCallback) {
+    this.topicId = topicId;
+    this.log = logCallback;
+  }
+
+  async run() {
+    try {
+      this.log("Starting decryption...");
+
+      const topicId = this.topicId;
+
+      this.log("Fetching raw topic data...");
+      const encryptedData = await ajax(
+        `/encrypt/data_for_decryption.json?topic_id=${topicId}`
+      );
+
+      this.log("Loading topic encrypting key...");
+      const topicKey = await getTopicKey(topicId);
+
+      this.log("Decrypting title...");
+      const decryptedTitle = (await decrypt(topicKey, encryptedData.title)).raw;
+
+      const decryptedPosts = {};
+      const decryptedPostPromises = [];
+
+      this.log("Queuing posts for decryption...");
+      for (const [id, post] of Object.entries(encryptedData.posts)) {
+        const promise = decrypt(topicKey, post)
+          .then((decryptedPost) => (decryptedPosts[id] = decryptedPost.raw))
+          .catch((error) => {
+            throw new Error(`Unable to decrypt post ${id}: ${error}`);
+          });
+        decryptedPostPromises.push(promise);
+      }
+
+      this.log("Waiting for posts to decrypt...");
+      await Promise.all(decryptedPostPromises);
+
+      this.log("Checking for encrypted uploads...");
+      for (let [id, post] of Object.entries(decryptedPosts)) {
+        for (const [, rawMetadata, shortUrl] of [
+          ...post.matchAll(UPLOAD_REGEX),
+        ]) {
+          this.log(`  Found ${shortUrl} in post ${id}...`);
+          const metadata = rawMetadata.split("|");
+
+          const type = metadata
+            .find((m) => m.startsWith("type="))
+            ?.split("=")?.[1];
+          if (!type) {
+            throw new Error(`Could not determine type of upload ${shortUrl}`);
+          }
+
+          const key = metadata
+            .find((m) => m.startsWith("key="))
+            ?.split("=")?.[1];
+          if (!key) {
+            throw new Error(`Could not determine key of upload ${shortUrl}`);
+          }
+
+          const urlData = lookupCachedUploadUrl(shortUrl);
+
+          const url = urlData.short_path;
+          if (!url) {
+            throw new Error(`Could not find full URL for upload ${shortUrl}`);
+          }
+
+          const keyPromise = new Promise((resolve, reject) => {
+            window.crypto.subtle
+              .importKey(
+                "raw",
+                base64ToBuffer(key),
+                { name: "AES-GCM", length: 256 },
+                true,
+                ["encrypt", "decrypt"]
+              )
+              .then(resolve, reject);
+          });
+
+          this.log(`    Downloading and decrypting ${shortUrl}...`);
+          const decryptedDownloadedFile = await downloadEncryptedFile(
+            url,
+            keyPromise,
+            { type }
+          );
+          this.log(`    Re-uploading ${shortUrl}...`);
+          const newShortUrl = await this.uploadBlob(
+            decryptedDownloadedFile.blob,
+            decryptedDownloadedFile.name.replace(".encrypted", "")
+          );
+          this.log(`    Uploaded as ${newShortUrl}.`);
+
+          post = post.replace(shortUrl, newShortUrl);
+        }
+
+        decryptedPosts[id] = post;
+      }
+
+      this.log(`Updating topic with decrypted data...`);
+      await ajax("/encrypt/complete_decryption.json", {
+        type: "POST",
+        data: {
+          topic_id: topicId,
+          title: decryptedTitle,
+          posts: decryptedPosts,
+        },
+      });
+
+      this.log(`Done!`);
+      return true;
+    } catch (e) {
+      this.log(`Error: ${e}`);
+      throw e;
+    }
+  }
+
+  async uploadBlob(blob, filename) {
+    const formData = new FormData();
+    formData.append("files[]", blob, filename);
+    formData.append("upload_type", "composer");
+
+    const result = await ajax("/uploads.json", {
+      type: "POST",
+      data: formData,
+      processData: false,
+      contentType: false,
+    });
+
+    return result.short_url;
+  }
+}

--- a/assets/javascripts/lib/permanent-topic-decrypter.js
+++ b/assets/javascripts/lib/permanent-topic-decrypter.js
@@ -109,7 +109,7 @@ export default class PermanentTopicDecrypter {
         decryptedPosts[id] = post;
       }
 
-      this.log(`Updating topic with decrypted data...`);
+      this.log("Updating topic with decrypted data...");
       await ajax("/encrypt/complete_decryption.json", {
         type: "POST",
         data: {
@@ -119,7 +119,7 @@ export default class PermanentTopicDecrypter {
         },
       });
 
-      this.log(`Done!`);
+      this.log("Done!");
       return true;
     } catch (e) {
       this.log(`Error: ${e}`);

--- a/assets/stylesheets/common/encrypt.scss
+++ b/assets/stylesheets/common/encrypt.scss
@@ -204,3 +204,7 @@ body.encrypted-topic-page {
     cursor: not-allowed !important;
   }
 }
+
+.decrypt-topic-button {
+  margin-top: 1em;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -35,7 +35,7 @@ en:
       decrypt_permanently:
         button: "Convert to unencrypted PM"
         modal_title: "Decrypt this PM permanently?"
-        modal_body: "This will decrypt all posts in this PM and convert it to a regular PM. This will apply to all participants. Are you sure you want to proceed?"
+        modal_body: "This will decrypt all posts in this PM and convert it to a regular PM. This will apply to all participants. Post content will be more easily accessible to community admins. Are you sure you want to proceed?"
         modal_confirm: "Yes, decrypt permanently"
         modal_cancel: "No, cancel"
         refresh_page: "Refresh"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -32,6 +32,14 @@ en:
         checked: "This message will be end-to-end encrypted."
         unchecked: "Click the lock symbol to encrypt this message."
 
+      decrypt_permanently:
+        button: "Convert to unencrypted PM"
+        modal_title: "Decrypt this PM permanently?"
+        modal_body: "This will decrypt all posts in this PM and convert it to a regular PM. This will apply to all participants. Are you sure you want to proceed?"
+        modal_confirm: "Yes, decrypt permanently"
+        modal_cancel: "No, cancel"
+        refresh_page: "Refresh"
+
       post:
         delete:
           title: "Are you sure?"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,6 +11,7 @@ en:
     encrypt_groups: "The name of groups that are able to use encryption (empty means everyone)."
     encrypt_pms_default: "Encrypt all new private messages by default."
     allow_new_encrypted_pms: "Allow users to create new encrypted private messages. Disabling this will limit discourse-encrypt use to existing encrypted PMs."
+    allow_decrypting_pms: "Allow users to permanently decrypt encrypted private messages."
 
     errors:
       encrypt_unsafe_csp: "Unsafe CSP directives like 'unsafe-eval' and 'unsafe-inline' cannot be used when the Discourse Encrypt plugin is enabled."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,3 +18,6 @@ plugins:
   allow_new_encrypted_pms:
     default: true
     client: true
+  allow_decrypting_pms:
+    default: false
+    client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -83,6 +83,8 @@ after_initialize do
     put "/encrypt/rotate" => "encrypt#update_all_keys"
     post "/encrypt/encrypted_post_timers" => "encrypted_post_timers#create"
     delete "/encrypt/encrypted_post_timers" => "encrypted_post_timers#destroy"
+    get "/encrypt/data_for_decryption" => "encrypt#data_for_decryption"
+    post "/encrypt/complete_decryption" => "encrypt#complete_decryption"
   end
 
   Discourse::Application.routes.prepend { mount DiscourseEncrypt::Engine, at: "/" }

--- a/spec/system/decrypt_encrypted_topic_posts_spec.rb
+++ b/spec/system/decrypt_encrypted_topic_posts_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Encrypt | Decypting topic posts", type: :system, js: true do
+describe "Encrypt | Decypting topic posts", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }

--- a/spec/system/decrypt_encrypted_topic_posts_spec.rb
+++ b/spec/system/decrypt_encrypted_topic_posts_spec.rb
@@ -27,7 +27,7 @@ describe "Encrypt | Decypting topic posts", type: :system, js: true do
     fab!(:tag) { Fabricate(:tag, name: "bugs") }
     fab!(:other_user) { Fabricate(:user) }
 
-    xit "decrypts the post" do
+    it "decrypts the post" do
       enable_encrypt_for_user_in_session(other_user, user_preferences_page)
 
       topic_page.open_new_message
@@ -42,7 +42,7 @@ describe "Encrypt | Decypting topic posts", type: :system, js: true do
       # encryption loading and processing takes a little longer than usual
       using_wait_time(5) do
         expect(find(".fancy-title")).to have_content(topic_title)
-        expect(page).to have_css(".d-icon-user-secret.private-message-glyph")
+        expect(page).to have_css(".topic-status .d-icon-user-secret")
         expect(page).to have_content("Here are some hashtags for decryption later")
       end
 
@@ -57,7 +57,7 @@ describe "Encrypt | Decypting topic posts", type: :system, js: true do
     fab!(:user_3) { Fabricate(:user) }
     fab!(:other_user) { Fabricate(:user) }
 
-    xit "decrypts the post" do
+    it "decrypts the post" do
       enable_encrypt_for_user_in_session(other_user, user_preferences_page)
 
       topic_page.open_new_message
@@ -74,7 +74,7 @@ describe "Encrypt | Decypting topic posts", type: :system, js: true do
       # encryption loading and processing takes a little longer than usual
       using_wait_time(5) do
         expect(find(".fancy-title")).to have_content(topic_title)
-        expect(page).to have_css(".d-icon-user-secret.private-message-glyph")
+        expect(page).to have_css(".topic-status .d-icon-user-secret")
         expect(page).to have_content("Here are some mentions for decryption later")
       end
 

--- a/spec/system/enable_encryption_spec.rb
+++ b/spec/system/enable_encryption_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Encrypt | Enabling encrypted messages", type: :system, js: true do
+describe "Encrypt | Enabling encrypted messages", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   before do
     encrypt_system_bootstrap(current_user)

--- a/spec/system/enable_encryption_spec.rb
+++ b/spec/system/enable_encryption_spec.rb
@@ -9,7 +9,7 @@ describe "Encrypt | Enabling encrypted messages", type: :system, js: true do
 
   let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }
 
-  xit "shows warning about paper keys when encryption is enabled" do
+  it "shows warning about paper keys when encryption is enabled" do
     user_preferences_page.visit(current_user)
     click_link "Security"
     find("#enable-encrypted-messages").click
@@ -20,7 +20,7 @@ describe "Encrypt | Enabling encrypted messages", type: :system, js: true do
     expect(current_user.reload.user_encryption_key.encrypt_private).to eq(nil)
   end
 
-  xit "enables encryption and generates paper keys" do
+  it "enables encryption and generates paper keys" do
     user_preferences_page.visit(current_user)
     click_link "Security"
     find("#enable-encrypted-messages").click
@@ -35,7 +35,7 @@ describe "Encrypt | Enabling encrypted messages", type: :system, js: true do
     end
   end
 
-  xit "activates encrypted messages on the device" do
+  it "activates encrypted messages on the device" do
     enable_encrypt_with_keys_for_user(current_user)
     user_preferences_page.visit(current_user)
     click_link "Security"

--- a/spec/system/permanent_decrypt_spec.rb
+++ b/spec/system/permanent_decrypt_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+describe "Encrypt | Decypting topic posts", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:category) { Fabricate(:category, name: "TODO", slug: "todo") }
+  fab!(:tag) { Fabricate(:tag, name: "bugs") }
+  fab!(:other_user) { Fabricate(:user) }
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:composer) { PageObjects::Components::Composer.new }
+  let(:topic_title) { "My super secret topic" }
+  let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }
+
+  before do
+    SiteSetting.allow_decrypting_pms = true
+    encrypt_system_bootstrap(current_user)
+    sign_in(current_user)
+    enable_encrypt_with_keys_for_user(current_user)
+    activate_encrypt(user_preferences_page, current_user)
+  end
+
+  def select_other_user_for_pm
+    find("#private-message-users").click
+    find("#private-message-users-filter input[name='filter-input-search']").send_keys(
+      other_user.username,
+    )
+    find(".email-group-user-chooser-row").click
+  end
+
+  it "can permanently decrypt the topic" do
+    enable_encrypt_for_user_in_session(other_user, user_preferences_page)
+
+    topic_page.open_new_message
+    expect(page).to have_css(".encrypt-controls .d-icon-lock")
+
+    select_other_user_for_pm
+
+    # Create encrypted PM
+    topic_page.fill_in_composer_title(topic_title)
+    topic_page.fill_in_composer("This is an initial post in the encrypted PM")
+    topic_page.send_reply
+
+    # Check it worked, and post a reply
+    expect(find(".fancy-title")).to have_content(topic_title)
+    expect(page).to have_css(".topic-status .d-icon-user-secret")
+    expect(find("#post_1")).to have_content("This is an initial post in the encrypted PM")
+    topic_page.click_reply_button
+    topic_page.fill_in_composer("This is a reply to the encrypted PM")
+    attach_file(file_from_fixtures("logo.png", "images").path) do
+      composer.click_toolbar_button("upload")
+    end
+    expect(page).to have_no_css("#file-uploading")
+    topic_page.send_reply
+
+    expect(find("#post_2")).to have_content("This is a reply to the encrypted PM")
+
+    try_until_success do
+      upload = Topic.last.posts.last.uploads.first
+      expect(upload).to be_present
+      expect(upload.url).to end_with(".encrypted")
+    end
+
+    # Permanently decrypt the topic
+    find(".decrypt-topic-button").click
+    expect(page).to have_css(".decrypt-topic-modal")
+    find(".d-modal__footer .btn-primary").click
+    expect(find(".d-modal__body pre")).to have_content("Refresh page to continue")
+    find(".d-modal__footer .btn-primary").click
+
+    # Check the topic is decrypted
+    expect(page).not_to have_css("body.encrypted-topic-page")
+    expect(page).to have_css(".private-message-glyph")
+    expect(find("#post_1")).to have_content("This is an initial post in the encrypted PM")
+    expect(find("#post_2")).to have_content("This is a reply to the encrypted PM")
+
+    # Check database state is good
+    expect(Topic.last.is_encrypted?).to eq(false)
+    upload = Topic.last.posts.last.uploads.first
+    expect(upload).to be_present
+    expect(upload.url).not_to end_with(".encrypted")
+  end
+end

--- a/spec/system/permanent_decrypt_spec.rb
+++ b/spec/system/permanent_decrypt_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Encrypt | Decypting topic posts", type: :system, js: true do
+describe "Encrypt | Decypting topic posts", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:category) { Fabricate(:category, name: "TODO", slug: "todo") }
   fab!(:tag) { Fabricate(:tag, name: "bugs") }


### PR DESCRIPTION
Introduces a new site setting: 'allow_decrypting_pms'

When enabled, a new button is added below the title of any encrypted PM. This can be used by any participant to decrypt the entire topic (including uploads) permanently, and turn the topic into a regular unencrypted PM.

Also unskips and fixes-up all the system specs. We no longer run encrypt as part of the Discourse core test suite, so the prior concerns about flakiness should be less of an issue.

<img width="500" alt="SCR-20241106-ntnl" src="https://github.com/user-attachments/assets/28b54a1c-e2c1-48b9-8dbd-2a73f4d36f5c">
<img width="500" alt="SCR-20241106-ntpd" src="https://github.com/user-attachments/assets/3618c79a-0649-465c-8b2b-6503d309578c">
<img width="500" alt="SCR-20241106-ntqi" src="https://github.com/user-attachments/assets/03818767-e0d1-4e7c-89a7-d1b8e800680a">
