### PR TITLE
FIX: Decryption on sites with external uploads

### DIFF
--- a/assets/javascripts/lib/permanent-topic-decrypter.js
+++ b/assets/javascripts/lib/permanent-topic-decrypter.js
@@ -99,7 +99,7 @@ export default class PermanentTopicDecrypter {
           this.log(`    Re-uploading ${shortUrl}...`);
           const newShortUrl = await this.uploadBlob(
             decryptedDownloadedFile.blob,
-            decryptedDownloadedFile.name.replace(".encrypted", "")
+            decryptedDownloadedFile.name?.replace(".encrypted", "")
           );
           this.log(`    Uploaded as ${newShortUrl}.`);
 


### PR DESCRIPTION
Filenames are not available to JS in this case, because of CORS concerns. Upload without an original filename.

Followup to 658b87f9c169bba04ec5a701eb90e6365c7e5ecf