### PR TITLE
FIX: Do not bump topics when decrypting

### DIFF
--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -266,17 +266,14 @@ class DiscourseEncrypt::EncryptController < ApplicationController
       decrypted_posts.each do |post_id, raw|
         post = topic.posts.find(post_id)
 
-        revision = { raw: raw }
+        changes = { raw: raw, edit_reason: "Decrypting topic" }
 
-        revision[:title] = decrypted_title if post.post_number == 1
+        changes[:title] = decrypted_title if post.post_number == 1
 
         post.revise(
           current_user,
-          **revision,
-          skip_validations: true,
-          bypass_rate_limiter: true,
-          bypass_bump: true,
-          edit_reason: "Decrypting topic",
+          changes,
+          { skip_validations: true, bypass_rate_limiter: true, bypass_bump: true },
         )
       end
       topic.encrypted_topics_data.destroy!

--- a/spec/system/permanent_decrypt_spec.rb
+++ b/spec/system/permanent_decrypt_spec.rb
@@ -60,6 +60,8 @@ describe "Encrypt | Decypting topic posts", type: :system do
       expect(upload.url).to end_with(".encrypted")
     end
 
+    initial_bump_date = Topic.last.bumped_at
+
     # Permanently decrypt the topic
     find(".decrypt-topic-button").click
     expect(page).to have_css(".decrypt-topic-modal")
@@ -78,5 +80,6 @@ describe "Encrypt | Decypting topic posts", type: :system do
     upload = Topic.last.posts.last.uploads.first
     expect(upload).to be_present
     expect(upload.url).not_to end_with(".encrypted")
+    expect(Topic.last.bumped_at).to eq(initial_bump_date) # rubocop:disable Discourse/TimeEqMatcher because it should be precisely the same
   end
 end


### PR DESCRIPTION
Followup to 658b87f9c169bba04ec5a701eb90e6365c7e5ecf