### PR TITLE
UX: Avoid triggering notifications when decrypting

### DIFF
--- a/app/controllers/encrypt_controller.rb
+++ b/app/controllers/encrypt_controller.rb
@@ -266,12 +266,12 @@ class DiscourseEncrypt::EncryptController < ApplicationController
       decrypted_posts.each do |post_id, raw|
         post = topic.posts.find(post_id)
 
-        changes = { raw: raw, edit_reason: "Decrypting topic" }
+        changes = { raw: raw, edit_reason: "@#{current_user.username} decrypted topic" }
 
         changes[:title] = decrypted_title if post.post_number == 1
 
         post.revise(
-          current_user,
+          Discourse.system_user,
           changes,
           { skip_validations: true, bypass_rate_limiter: true, bypass_bump: true },
         )

--- a/spec/system/permanent_decrypt_spec.rb
+++ b/spec/system/permanent_decrypt_spec.rb
@@ -19,30 +19,42 @@ describe "Encrypt | Decypting topic posts", type: :system do
     activate_encrypt(user_preferences_page, current_user)
   end
 
-  def select_self_as_recipient
+  def select_recipient(username)
     find("#private-message-users").click
-    find("#private-message-users-filter input[name='filter-input-search']").send_keys(
-      current_user.username,
-    )
+    find("#private-message-users-filter input[name='filter-input-search']").send_keys(username)
     find(".email-group-user-chooser-row").click
     find("#private-message-users").click
   end
 
   it "can permanently decrypt the topic" do
+    Jobs.run_immediately!
+
     topic_page.open_new_message
     expect(page).to have_css(".encrypt-controls .d-icon-lock")
 
-    select_self_as_recipient
+    enable_encrypt_for_user_in_session(other_user, user_preferences_page)
+    select_recipient(other_user.username)
 
     # Create encrypted PM
     topic_page.fill_in_composer_title(topic_title)
     topic_page.fill_in_composer("This is an initial post in the encrypted PM")
     topic_page.send_reply
 
-    # Check it worked, and post a reply
+    # Check it worked
     expect(find(".fancy-title")).to have_content(topic_title)
     expect(page).to have_css(".topic-status .d-icon-user-secret")
     expect(find("#post_1")).to have_content("This is an initial post in the encrypted PM")
+
+    # Reply from other user
+    using_session("user_#{other_user.username}_enable_encrypt") do
+      visit "/t/#{Topic.last.id}"
+      topic_page.click_reply_button
+      topic_page.fill_in_composer("Reply from other user")
+      topic_page.send_reply
+      expect(find("#post_2")).to have_content("Reply from other user")
+    end
+
+    # Final reply from initial user, with uploads
     topic_page.click_reply_button
     topic_page.fill_in_composer("This is a reply to the encrypted PM")
     attach_file(file_from_fixtures("logo.png", "images").path) do
@@ -51,7 +63,7 @@ describe "Encrypt | Decypting topic posts", type: :system do
     expect(page).to have_no_css("#file-uploading")
     topic_page.send_reply
 
-    expect(find("#post_2")).to have_content("This is a reply to the encrypted PM")
+    expect(find("#post_3")).to have_content("This is a reply to the encrypted PM")
 
     try_until_success do
       upload = Topic.last.posts.last.uploads.first
@@ -60,6 +72,7 @@ describe "Encrypt | Decypting topic posts", type: :system do
     end
 
     initial_bump_date = Topic.last.bumped_at
+    initial_notification_count = Notification.count
 
     # Permanently decrypt the topic
     find(".decrypt-topic-button").click
@@ -72,7 +85,8 @@ describe "Encrypt | Decypting topic posts", type: :system do
     expect(page).not_to have_css("body.encrypted-topic-page")
     expect(page).to have_css(".private-message-glyph")
     expect(find("#post_1")).to have_content("This is an initial post in the encrypted PM")
-    expect(find("#post_2")).to have_content("This is a reply to the encrypted PM")
+    expect(find("#post_2")).to have_content("Reply from other user")
+    expect(find("#post_3")).to have_content("This is a reply to the encrypted PM")
 
     # Check database state is good
     expect(Topic.last.is_encrypted?).to eq(false)
@@ -80,13 +94,14 @@ describe "Encrypt | Decypting topic posts", type: :system do
     expect(upload).to be_present
     expect(upload.url).not_to end_with(".encrypted")
     expect(Topic.last.bumped_at).to eq(initial_bump_date) # rubocop:disable Discourse/TimeEqMatcher because it should be precisely the same
+    expect(Notification.count).to eq(initial_notification_count)
   end
 
   it "can permanently decrypt multiple topics" do
     3.times do |i|
       topic_page.open_new_message
       expect(page).to have_css(".encrypt-controls .d-icon-lock")
-      select_self_as_recipient
+      select_recipient(current_user.username)
 
       # Create encrypted PM
       topic_page.fill_in_composer_title(topic_title)


### PR DESCRIPTION
System user edits will never trigger notifications (see PostRevisor#alert_users). The acting user is still recorded in the edit_reason for auditing purposes.