### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/encrypt-enable-dropdown.js
+++ b/assets/javascripts/discourse/components/encrypt-enable-dropdown.js
@@ -27,7 +27,7 @@ export default class EncryptEnableDropdown extends DropdownSelectBoxComponent {
     if (this.isEncryptEnabled) {
       content.push({
         id: "reset",
-        icon: "trash-alt",
+        icon: "trash-can",
         name: I18n.t("encrypt.reset.title"),
       });
     }

--- a/assets/javascripts/discourse/components/encrypt-preferences-dropdown.js
+++ b/assets/javascripts/discourse/components/encrypt-preferences-dropdown.js
@@ -17,7 +17,7 @@ export default class EncryptPreferencesDropdown extends DropdownSelectBoxCompone
     },
     {
       id: "managePaperKeys",
-      icon: "ticket-alt",
+      icon: "ticket-simple",
       name: I18n.t("encrypt.manage_paper_keys.title"),
     },
     {
@@ -27,12 +27,12 @@ export default class EncryptPreferencesDropdown extends DropdownSelectBoxCompone
     },
     {
       id: "rotate",
-      icon: "sync",
+      icon: "arrows-rotate",
       name: I18n.t("encrypt.rotate.title"),
     },
     {
       id: "reset",
-      icon: "trash-alt",
+      icon: "trash-can",
       name: I18n.t("encrypt.reset.title"),
     },
   ];

--- a/assets/javascripts/discourse/components/modal/manage-paper-keys.hbs
+++ b/assets/javascripts/discourse/components/modal/manage-paper-keys.hbs
@@ -26,7 +26,7 @@
 
               <td>
                 <DButton
-                  @icon="far-trash-alt"
+                  @icon="far-trash-can"
                   @action={{fn this.delete key.label}}
                   @title="encrypt.manage_paper_keys.delete"
                   class="btn-danger pull-right"
@@ -43,7 +43,7 @@
 
   <:footer>
     <DButton
-      @icon="ticket-alt"
+      @icon="ticket-simple"
       @action={{this.generatePaperKey}}
       @label="encrypt.generate_paper_key.title"
     />

--- a/assets/javascripts/discourse/components/modal/reset-key-pair.hbs
+++ b/assets/javascripts/discourse/components/modal/reset-key-pair.hbs
@@ -30,7 +30,7 @@
   <:footer>
     <DButton
       class="btn btn-danger"
-      @icon="trash-alt"
+      @icon="trash-can"
       @label="encrypt.reset.title"
       @action={{this.reset}}
       @disabled={{this.disabled}}

--- a/assets/javascripts/discourse/components/modal/rotate-key-pair.hbs
+++ b/assets/javascripts/discourse/components/modal/rotate-key-pair.hbs
@@ -20,7 +20,7 @@
   <:footer>
     <DButton
       class="btn btn-primary"
-      @icon="sync"
+      @icon="arrows-rotate"
       @label={{this.label}}
       @action={{this.rotate}}
       @disabled={{this.disabled}}

--- a/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.hbs
+++ b/assets/javascripts/discourse/connectors/user-preferences-security/encrypt.hbs
@@ -18,7 +18,7 @@
               <p>{{i18n "encrypt.preferences.status_enabled"}}</p>
               <fieldset class="control-group">
                 <DButton
-                  @icon="times"
+                  @icon="xmark"
                   @action={{action "deactivateEncrypt"}}
                   @label="encrypt.preferences.deactivate"
                   id="encrypt-deactivate"
@@ -31,7 +31,7 @@
                 />
                 <DButton
                   id="encrypt-generate-paper-key"
-                  @icon="ticket-alt"
+                  @icon="ticket-simple"
                   @action={{action "generatePaperKey"}}
                   @label="encrypt.generate_paper_key.title"
                 />

--- a/assets/javascripts/discourse/initializers/decrypt-posts.js
+++ b/assets/javascripts/discourse/initializers/decrypt-posts.js
@@ -354,7 +354,7 @@ export default {
             ? "div.post-info.integrity-fail"
             : "div.post-info.integrity-warn",
           { title: messages.join(" ") },
-          iconNode(isError ? "times" : "exclamation-triangle")
+          iconNode(isError ? "xmark" : "triangle-exclamation")
         );
       });
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,16 +13,16 @@ register_asset "stylesheets/common/encrypt.scss"
 register_asset "stylesheets/colors.scss", :color_definitions
 %w[
   bars
-  exchange-alt
+  right-left
   far-clipboard
   file-export
   file-import
   lock
   plus
   discourse-trash-clock
-  ticket-alt
-  times
-  trash-alt
+  ticket-simple
+  xmark
+  trash-can
   unlock
   wrench
 ].each { |i| register_svg_icon(i) }


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.