### PR TITLE
FIX: deprecation message

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,7 +4,6 @@ en:
     enabled_already: "You have already enabled encrypted messages."
     only_pms: "Only private messages can be encrypted."
     no_encrypt_keys: "Something went wrong. No encryption keys were included in the payload."
-    deprecated: The discourse-encrypt plugin is deprecated, and support will be dropped in Q1 2025. For more information, see <a href="https://meta.discourse.org/t/107918">Discourse Meta</a>. Uninstall the plugin to remove this message.
 
   site_settings:
     encrypt_enabled: "Enable encrypted private messages."
@@ -16,3 +15,7 @@ en:
 
     errors:
       encrypt_unsafe_csp: "Unsafe CSP directives like 'unsafe-eval' and 'unsafe-inline' cannot be used when the Discourse Encrypt plugin is enabled."
+
+  dashboard:
+    problem:
+      encrypt_deprecated: The discourse-encrypt plugin is deprecated, and support will be dropped in Q1 2025. For more information, see <a href="https://meta.discourse.org/t/107918">Discourse Meta</a>. Uninstall the plugin to remove this message.

--- a/plugin.rb
+++ b/plugin.rb
@@ -112,19 +112,19 @@ after_initialize do
 
   register_problem_check ProblemCheck::UnsafeCsp
 
-  class DiscourseEncrypt::DeprecatedCheck < ProblemCheck
+  class DiscourseEncrypt::EncryptDeprecated < ProblemCheck
     self.priority = "high"
 
     def call
       problem
     end
 
-    def translation_key
-      "encrypt.deprecated"
+    def identifier
+      "encrypt_deprecated"
     end
   end
 
-  register_problem_check DiscourseEncrypt::DeprecatedCheck
+  register_problem_check DiscourseEncrypt::EncryptDeprecated
 
   register_search_topic_eager_load do |opts|
     if SiteSetting.encrypt_enabled? && opts[:search_pms]


### PR DESCRIPTION
ProblemChecks are supposed to support custom translation keys, but this isn't supported everywhere. e.g. it's hardcoded here: https://github.com/discourse/discourse/blob/eaa45ae4d0/app/models/admin_notice.rb#L10-L11

Moving encrypt's key to the standard location, so that